### PR TITLE
Che bato/manual disconnect

### DIFF
--- a/src/app/_components/Gameboard/OpponentCardTray/OpponentCardTray.tsx
+++ b/src/app/_components/Gameboard/OpponentCardTray/OpponentCardTray.tsx
@@ -42,9 +42,10 @@ const OpponentCardTray: React.FC<IOpponentCardTrayProps> = ({ trayPlayer }) => {
         }
     };
 
-    const { gameState, connectedPlayer, getOpponent } = useGame();
+    const { gameState, connectedPlayer, getOpponent, sendManualDisconnectMessage } = useGame();
     const router = useRouter();
     const handleExitButton = () =>{
+        sendManualDisconnectMessage();
         router.push('/');
     }
 

--- a/src/app/_components/Lobby/Players/Players.tsx
+++ b/src/app/_components/Lobby/Players/Players.tsx
@@ -113,6 +113,7 @@ const Players: React.FC<IPlayersProps> = ({ isLobbyView }) => {
                                 isLobbyView={true}
                                 title={connectedUser ? connectedUser.username : connectedPlayer}
                                 card={playerLeader}
+                                disabled={true}
                             />
                             <LeaderBaseCard variant="base" isLobbyView={true} card={playerBase}></LeaderBaseCard>
                         </Box>
@@ -133,6 +134,7 @@ const Players: React.FC<IPlayersProps> = ({ isLobbyView }) => {
                                 isLobbyView={isLobbyView}
                                 title={titleOpponent}
                                 card={opponentLeader}
+                                disabled={true}
                             />
                             <LeaderBaseCard variant="base" isLobbyView={isLobbyView} card={opponentBase}></LeaderBaseCard>
                         </Box>

--- a/src/app/_components/Lobby/Players/Players.tsx
+++ b/src/app/_components/Lobby/Players/Players.tsx
@@ -115,7 +115,7 @@ const Players: React.FC<IPlayersProps> = ({ isLobbyView }) => {
                                 card={playerLeader}
                                 disabled={true}
                             />
-                            <LeaderBaseCard variant="base" isLobbyView={true} card={playerBase}></LeaderBaseCard>
+                            <LeaderBaseCard variant="base" isLobbyView={true} card={playerBase} disabled={true}></LeaderBaseCard>
                         </Box>
                     </Grid>
                     <Grid sx={rowStyle}>
@@ -136,7 +136,7 @@ const Players: React.FC<IPlayersProps> = ({ isLobbyView }) => {
                                 card={opponentLeader}
                                 disabled={true}
                             />
-                            <LeaderBaseCard variant="base" isLobbyView={isLobbyView} card={opponentBase}></LeaderBaseCard>
+                            <LeaderBaseCard variant="base" isLobbyView={isLobbyView} card={opponentBase} disabled={true}></LeaderBaseCard>
                         </Box>
                     </Grid>
                 </Grid>

--- a/src/app/_contexts/Game.context.tsx
+++ b/src/app/_contexts/Game.context.tsx
@@ -21,6 +21,7 @@ interface IGameContextType {
     getOpponent: (player: string) => string;
     connectedPlayer: string;
     sendLobbyMessage: (args: any[]) => void;
+    sendManualDisconnectMessage: () => void;
 }
 
 const GameContext = createContext<IGameContextType | undefined>(undefined);
@@ -98,6 +99,11 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
         socket?.emit(message, ...args);
     };
 
+    const sendManualDisconnectMessage = () =>{
+        console.log('sending manual disconnect message');
+        socket?.emit('manualDisconnect')
+    }
+
     const sendGameMessage = (args: any[]) => {
         console.log('sending game message', args);
         socket?.emit('game', ...args);
@@ -123,7 +129,8 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
                 sendMessage,
                 connectedPlayer,
                 getOpponent,
-                sendLobbyMessage
+                sendLobbyMessage,
+                sendManualDisconnectMessage
             }}
         >
             {children}

--- a/src/app/_contexts/Game.context.tsx
+++ b/src/app/_contexts/Game.context.tsx
@@ -38,8 +38,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     useEffect(() => {
         const lobbyId = searchParams.get('lobbyId');
         // we get the lobbyId
-        const storedUnknownUserId = localStorage.getItem('unknownUserId') || lobbyId ? lobbyId+'-GuestId2' : null;
-
+        const storedUnknownUserId = localStorage.getItem('unknownUserId') || (lobbyId ? lobbyId + '-GuestId2' : null);
         // we set the username of the player based on whether it is in the localStorage or not.
         const username = localStorage.getItem('unknownUsername') || 'Player2';
         const connectedPlayerId = user?.id || storedUnknownUserId || '';
@@ -53,7 +52,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
         });
 
         const handleGameStatePopups = (gameState: any) => {
-            if (!user || user.id == null) return;
+            if (!user || user.id == null) return; // TODO currently this doesn't support private lobbies where players aren't logged in.
             if (gameState.players?.[user.id].promptState) {
                 const promptState = gameState.players?.[user.id].promptState;
                 const { buttons, menuTitle,promptTitle, promptUuid, selectCard, promptType, dropdownListOptions } =

--- a/src/app/_contexts/Game.context.tsx
+++ b/src/app/_contexts/Game.context.tsx
@@ -38,7 +38,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     useEffect(() => {
         const lobbyId = searchParams.get('lobbyId');
         // we get the lobbyId
-        const storedUnknownUserId = localStorage.getItem('unknownUserId') || lobbyId+'-GuestId2';
+        const storedUnknownUserId = localStorage.getItem('unknownUserId') || lobbyId ? lobbyId+'-GuestId2' : null;
 
         // we set the username of the player based on whether it is in the localStorage or not.
         const username = localStorage.getItem('unknownUsername') || 'Player2';


### PR DESCRIPTION
# Changes
### OpponentCardTray.tsx
- Added sendManualDisconnectMessage event so that we notify the server that this user is making a manualDisconnect.

### Players.tsx
- Added disabled = {true} to the leader & base cards since they were clickable in the lobby.

### Game.context.tsx
- Fixed bug with storedUnknownUserId when creating a private lobby the statement was written wrongly.
- Added SendManualDisconnectMessage function to notify the server when a user is making a manualDisconnect. 
