### PR TITLE
Added styling for cards that have not yet been implemented.

### DIFF
--- a/public/not-implemented.svg
+++ b/public/not-implemented.svg
@@ -1,0 +1,5 @@
+<svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect opacity="0.6" width="50" height="50" rx="25" fill="#ff1e1e"/>
+<rect x="18" y="14" width="14" height="22" rx="2" stroke="white" stroke-width="2"/>
+<path d="M13.3232 29.6443C12.3877 30.2007 12.0804 31.41 12.6367 32.3455C13.1931 33.281 14.4025 33.5883 15.338 33.032L36.6796 20.3392C37.615 19.7829 37.9224 18.5735 37.366 17.638C36.8096 16.7026 35.6003 16.3952 34.6648 16.9516L13.3232 29.6443Z" fill="white" stroke="#ff1e1e" stroke-width="2"/>
+</svg>

--- a/src/app/_components/_sharedcomponents/Cards/CardTypes.ts
+++ b/src/app/_components/_sharedcomponents/Cards/CardTypes.ts
@@ -10,6 +10,7 @@ export interface ICardData {
     parentCardId?: string,
     id?: number;
     name?: string;
+    implemented?: boolean;
     selected?: boolean;
     selectable: boolean;
     disabled?: boolean;

--- a/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
@@ -85,6 +85,7 @@ const GameCard: React.FC<IGameCardProps> = ({
     const styles = {
         cardStyles: {
             borderRadius: '.38em',
+            position: 'relative',
             ...(variant === 'lobby'
                 ? {
                     height: '13rem',
@@ -123,6 +124,11 @@ const GameCard: React.FC<IGameCardProps> = ({
             backgroundSize: size === 'standard' ? 'contain' : 'cover',
             backgroundPosition: size === 'standard' ? 'center' : 'top',
             backgroundRepeat: 'no-repeat',
+            ...(!(cardData?.implemented ?? false)
+                ? {
+                    filter: 'grayScale(100%)',
+                } : null
+            ),
         },
         imageStyle: {
             width: '2.5rem',
@@ -251,6 +257,27 @@ const GameCard: React.FC<IGameCardProps> = ({
             backgroundImage: 'url(/SentinelToken.png)',
             alignItems: 'center',
             justifyContent: 'center',
+        },
+        unimplementedContainerStyle: {
+            position: 'absolute',
+            height: '100%',
+            width: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: '2',
+            top: '0',
+            left: '0'
+        },
+        unimplementedAlertStyle: {
+            fontSize: '1rem',
+            fontWeight: '700',
+            backgroundImage: 'url(/not-implemented.svg)',
+            backgroundPosition: 'center',
+            backgroundSize: 'contain',
+            backgroundRepeat: 'no-repeat',
+            height: '40px',
+            width: '40px',
         }
     }
     return (
@@ -259,6 +286,12 @@ const GameCard: React.FC<IGameCardProps> = ({
 
                 onClick={disabled ? undefined : handleClick}
             >
+                {/* This adds a layer on top of the card to indicate that the card is not yet implemented. */}
+                {isFaceUp === true && !(cardData?.implemented ?? false) && (
+                    <CardContent sx={styles.unimplementedContainerStyle}>
+                        <Box sx={styles.unimplementedAlertStyle}></Box>
+                    </CardContent>
+                )}
                 {isFaceUp ? (
                     <CardContent sx={styles.cardContentStyle}>
                         <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>

--- a/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
@@ -6,7 +6,6 @@ import {
     Box,
 } from '@mui/material';
 import Grid from '@mui/material/Grid2';
-import Image from 'next/image';
 import { IGameCardProps, ICardData, IServerCardData } from './CardTypes';
 import { useGame } from '@/app/_contexts/Game.context';
 import { s3CardImageURL, s3TokenImageURL } from '@/app/_utils/s3Utils';
@@ -26,12 +25,12 @@ const GameCard: React.FC<IGameCardProps> = ({
     disabled = false,
 }) => {
     // const isLobbyView = path === "/lobby";
-    const isFaceUp = true;
-
+    
     // Determine whether card is ICardData or IServerCardData
     const cardData = isICardData(card) ? card : card.card;
     const cardCounter = !isICardData(card) ? card.count : 0;
     const { sendGameMessage, connectedPlayer, getConnectedPlayerPrompt } = useGame();
+    const isFaceUp = !!cardData;
 
     // default on click
     const defaultClickFunction = () => {
@@ -124,17 +123,13 @@ const GameCard: React.FC<IGameCardProps> = ({
             backgroundSize: size === 'standard' ? 'contain' : 'cover',
             backgroundPosition: size === 'standard' ? 'center' : 'top',
             backgroundRepeat: 'no-repeat',
-            ...(!(cardData?.implemented ?? false)
-                ? {
-                    filter: 'grayScale(100%)',
-                } : null
-            ),
         },
         cardOverlay: {
             position: 'absolute',
             width: '100%',
             height: '100%',
             backgroundColor: cardData?.exhausted ? 'rgba(0, 0, 0, 0.5)' : 'transparent',
+            filter: 'none',
             clickEvents: 'none',
         },
         imageStyle: {
@@ -269,7 +264,7 @@ const GameCard: React.FC<IGameCardProps> = ({
             position: 'absolute',
             height: '100%',
             width: '100%',
-            display: 'flex',
+            display: cardData?.implemented || !isFaceUp ? 'none' : 'flex',
             alignItems: 'center',
             justifyContent: 'center',
             zIndex: '2',
@@ -283,8 +278,9 @@ const GameCard: React.FC<IGameCardProps> = ({
             backgroundPosition: 'center',
             backgroundSize: 'contain',
             backgroundRepeat: 'no-repeat',
-            height: '40px',
-            width: '40px',
+            height: 'auto',
+            aspectRatio: '1/1',
+            width: '50%'
         }
     }
     return (
@@ -293,13 +289,10 @@ const GameCard: React.FC<IGameCardProps> = ({
 
                 onClick={disabled ? undefined : handleClick}
             >
-                {/* This adds a layer on top of the card to indicate that the card is not yet implemented. */}
-                {isFaceUp === true && !(cardData?.implemented ?? false) && (
-                    <CardContent sx={styles.unimplementedContainerStyle}>
+                <Box sx={{ position: 'relative', height: '100%', width: '100%', backgroundColor: 'transparent' }}>
+                    <Box sx={styles.unimplementedContainerStyle}>
                         <Box sx={styles.unimplementedAlertStyle}></Box>
-                    </CardContent>
-                )}
-                {isFaceUp ? (
+                    </Box>
                     <CardContent sx={styles.cardContentStyle}>
                         <Box sx={styles.cardOverlay}></Box>
                         <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
@@ -337,26 +330,7 @@ const GameCard: React.FC<IGameCardProps> = ({
                             </>
                         ) : null}
                     </CardContent>
-                ) : (
-                    <CardContent sx={styles.cardContentStyle}>
-                        <Image
-                            src="/card-back.png"
-                            alt="Deck Image"
-                            width={28}
-                            height={38}
-                            placeholder="empty"
-                            style={styles.imageStyle}
-                        />
-                        {/* {deckSize && deckSize > 0 && (
-						<>
-							<Box sx={circularBackgroundStyle}></Box>
-							<Typography variant="body2" sx={deckSizeTextStyle}>
-								{deckSize}
-							</Typography>
-						</>
-					)} */}
-                    </CardContent>
-                )}
+                </Box>
             </MuiCard>
             {otherUpgradeCards.map((subcard, index) => (
                 <Box


### PR DESCRIPTION
Added logic to the Card that determines if a card has been implemented or not and gives the user a visual. Currently works in-game.

Something to note - in GameCard.tsx, line 29 sets isFaceUp = true but nowhere else does it confirm that to build the card. When testing, the "not implemented" styling weas applying to the opponent's cards in hand, but I was not able to figure out why that was the case. I would have assumed that checking isFaceUp was the fix, so I am not certain if this is some residual thing.