### PR TITLE
Anonymous user support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
 				"react": "^18",
 				"react-dom": "^18",
 				"react-icons": "^5.3.0",
-				"socket.io-client": "^4.8.1"
+				"socket.io-client": "^4.8.1",
+				"uuid": "^11.0.5"
 			},
 			"devDependencies": {
 				"@stylistic/eslint-plugin": "^2.12.1",
@@ -4189,6 +4190,14 @@
 				}
 			}
 		},
+		"node_modules/next-auth/node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/oauth": {
 			"version": "0.9.15",
 			"resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
@@ -5573,11 +5582,15 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"version": "11.0.5",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+			"integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 		"react": "^18",
 		"react-dom": "^18",
 		"react-icons": "^5.3.0",
-		"socket.io-client": "^4.8.1"
+		"socket.io-client": "^4.8.1",
+		"uuid": "^11.0.5"
 	},
 	"devDependencies": {
 		"@stylistic/eslint-plugin": "^2.12.1",

--- a/src/app/GameBoard/page.tsx
+++ b/src/app/GameBoard/page.tsx
@@ -19,6 +19,7 @@ import { MatchType } from '@/app/_constants/constants';
 
 const GameBoard = () => {
     const { getOpponent, connectedPlayer, gameState, lobbyState } = useGame();
+
     const router = useRouter();
     const { sidebarOpen, toggleSidebar } = useSidebar();
     const [chatMessage, setChatMessage] = useState('');
@@ -68,11 +69,6 @@ const GameBoard = () => {
         setPreferenceOpen(!isPreferenceOpen);
     }
 
-    // Ensure that essential state values are defined before rendering.
-    if (!gameState && !connectedPlayer && !lobbyState) {
-        return null;
-    }
-
     // check if game ended already.
     const winners = gameState?.winner ? gameState.winner : undefined;
     // const winners = ['order66']
@@ -81,9 +77,10 @@ const GameBoard = () => {
         ? ['endGame','keyboardShortcuts','cardSleeves','gameOptions']
         :['currentGame','keyboardShortcuts','cardSleeves','gameOptions']
 
-
+    if (!gameState || !connectedPlayer) {
+        return null;
+    }
     // ----------------------Styles-----------------------------//
-
     const styles = {
         mainBoxStyle: {
             flexGrow: 1,
@@ -112,10 +109,6 @@ const GameBoard = () => {
         'radial-gradient(ellipse, rgba(0,0,0, 0.9), rgba(0,0,0,0.7), rgba(0,0,0,0.0))',
         },
     };
-
-    if (!gameState || !connectedPlayer) {
-        return null;
-    }
 
     return (
         <Grid container sx={{ height: '100vh', overflow: 'hidden' }}>

--- a/src/app/_components/_sharedcomponents/CreateGameForm/CreateGameForm.tsx
+++ b/src/app/_components/_sharedcomponents/CreateGameForm/CreateGameForm.tsx
@@ -59,7 +59,7 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
         console.log('Save Deck To Favourites:', saveDeck);
         try {
             const payload = {
-                user: user,
+                user: user || sessionStorage.getItem('anonymousUserId'),
                 deck: deckData,
                 isPrivate: privacy === 'Private',
             };
@@ -76,12 +76,7 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
             if (!response.ok) {
                 throw new Error('Failed to create game');
             }
-            const responseJson = await response.json();
-            // Store unknownUserId in local storage (so we can retrieve it in GameContext)
-            if(privacy === 'Private') {
-                localStorage.setItem('unknownUserId', responseJson.newUserId);
-                localStorage.setItem('unknownUsername', 'Player1');
-            }
+
             router.push('/lobby');
         } catch (error) {
             console.error(error);

--- a/src/app/_contexts/Game.context.tsx
+++ b/src/app/_contexts/Game.context.tsx
@@ -40,11 +40,8 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
 
     useEffect(() => {
         const lobbyId = searchParams.get('lobbyId');
-        // we get the lobbyId
-        const storedUnknownUserId = localStorage.getItem('unknownUserId') || (lobbyId ? lobbyId + '-GuestId2' : null);
-        // we set the username of the player based on whether it is in the localStorage or not.
-        const username = localStorage.getItem('unknownUsername') || 'Player2';
-        const connectedPlayerId = user?.id || storedUnknownUserId || '';
+        const anonymousUserId = sessionStorage.getItem('anonymousUserId');
+        const connectedPlayerId = user?.id || anonymousUserId || '';
         setConnectedPlayer(connectedPlayerId);
         clearPopups();
 
@@ -53,13 +50,13 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
         const newSocket = io(`${process.env.NEXT_PUBLIC_ROOT_URL}`, {
             path: '/ws',
             query: {
-                user: JSON.stringify(user ? user : { username:username, id:storedUnknownUserId }),
+                user: JSON.stringify(user ? user : { username: '', id: anonymousUserId }),
                 lobby: JSON.stringify({ lobbyId:lobbyId ? lobbyId : null })
             },
         });
 
         const handleGameStatePopups = (gameState: any) => {
-            if (!connectedPlayerId) return; // TODO currently this doesn't support private lobbies where players aren't logged in.
+            if (!connectedPlayerId) return;
             if (gameState.players?.[connectedPlayerId].promptState) {
                 const promptState = gameState.players?.[connectedPlayerId].promptState;
                 const { buttons, menuTitle,promptTitle, promptUuid, selectCard, promptType, dropdownListOptions, perCardButtons, displayCards } =
@@ -99,9 +96,6 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
             }
         };
 
-        // newSocket.on('connect', () => {
-        //     console.log(`Connected to server as ${user ? user.username : ''}`);
-        // });
         newSocket.on('gamestate', (gameState: any) => {
             if (gameState?.id && gameState.id !== lastGameIdRef.current) {
                 clearPopups();
@@ -110,10 +104,6 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
             setGameState(gameState);
             console.log('Game state received:', gameState);
             handleGameStatePopups(gameState);
-        });
-        newSocket.on('connectedUser', () =>{
-            localStorage.removeItem('unknownUserId');
-            localStorage.removeItem('unknownUsername');
         });
         newSocket.on('lobbystate', (lobbyState: any) => {
             setLobbyState(lobbyState);

--- a/src/app/_contexts/User.context.tsx
+++ b/src/app/_contexts/User.context.tsx
@@ -6,11 +6,11 @@ import React, {
     ReactNode,
     useEffect,
     useState,
-    useCallback,
 } from 'react';
 import { useSession, signIn, signOut } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { IUserContextType } from './UserTypes';
+import { v4 as uuid } from 'uuid';
 
 const UserContext = createContext<IUserContextType>({
     user: null,
@@ -39,6 +39,12 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({
             setUser(null);
         }
     }, [session]);
+
+    useEffect(() => {
+        if (!user && !sessionStorage.getItem('anonymousUserId')) {
+            sessionStorage.setItem('anonymousUserId', uuid());
+        }
+    }, [user]);
 
     const login = (provider: 'google' | 'discord') => {
         signIn(provider, {


### PR DESCRIPTION
- Handles anonymous user assignment in the client to be passed to the back end for requests. 
- consolidates user login logic to assign and remove anonymous user properties when logins change.

There are a lot of change here to user login/persistence. We'll want to do a bit of manual testing to make sure that anonymous/logged in users can properly access their games and persist across refreshes. Logged in users use local storage so 2 logged in users still need to use incognito modes to simulate both users. Anonymous users use session storage which is unique for each tab so 2 anon users can use two tabs in the same browser. 