### PR TITLE
Che bato/capture mechanic

### DIFF
--- a/src/app/_components/Gameboard/_subcomponents/UnitsBoard.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/UnitsBoard.tsx
@@ -45,14 +45,51 @@ const UnitsBoard: React.FC<IUnitsBoardProps> = ({
             }));
         return mainCards;
     }
+
+    /**
+     * Takes an array of main unit cards and an array of captured cards,
+     * and returns a new array of unit cards where each card has a `capturedCards`
+     * property containing any captured cards that reference its uuid.
+     */
+    const attachCapturedCards = (
+        cards: ICardData[],
+        capturedCards: ICardData[]
+    ): ICardData[] => {
+        // Group captured cards by their parentCardId
+        const capturedMapping: Record<string, ICardData[]> = {};
+
+        capturedCards.forEach((card) => {
+            if (card.parentCardId) {
+                if (!capturedMapping[card.parentCardId]) {
+                    capturedMapping[card.parentCardId] = [];
+                }
+                capturedMapping[card.parentCardId].push(card);
+            }
+        });
+
+        // For each main unit card, attach any matching captured cards
+        return cards.map((card) => ({
+            ...card,
+            capturedCards: card.uuid ? capturedMapping[card.uuid] ?? [] : [],
+        }));
+    };
+
     const { gameState, connectedPlayer, getOpponent } = useGame();
 
     const rawPlayerUnits = gameState?.players[connectedPlayer].cardPiles[arena];
     const rawOpponentUnits = gameState?.players[getOpponent(connectedPlayer)].cardPiles[arena];
+    const allCapturedCards = gameState?.players[connectedPlayer].cardPiles['capturedZone'];
     const allCardsInArena = [...rawPlayerUnits, ...rawOpponentUnits];
+
     const upgradeMapping = findUpgrades(allCardsInArena);
-    const playerUnits = attachUpgrades(rawPlayerUnits, upgradeMapping);
-    const opponentUnits = attachUpgrades(rawOpponentUnits, upgradeMapping);
+
+    // attach upgrades to the unit cards
+    const playerUnitsWithUpgrades = attachUpgrades(rawPlayerUnits, upgradeMapping);
+    const opponentUnitsWithUpgrades = attachUpgrades(rawOpponentUnits, upgradeMapping);
+
+    // attach capturedCards to the unit cards
+    const playerUnits = attachCapturedCards(playerUnitsWithUpgrades, allCapturedCards);
+    const opponentUnits = attachCapturedCards(opponentUnitsWithUpgrades, allCapturedCards);
 
     const styles = {
         mainBoxStyle: {
@@ -90,7 +127,7 @@ const UnitsBoard: React.FC<IUnitsBoardProps> = ({
                 <Grid sx={styles.opponentGridStyle}>
                     {opponentUnits.map((card: ICardData) => (
                         <Box key={card.uuid} sx={{ flex: '0 0 auto' }}>
-                            <GameCard key={card.uuid} card={card} subcards={card.subcards} size="square" variant={'gameboard'}/>
+                            <GameCard key={card.uuid} card={card} subcards={card.subcards} capturedCards={card.capturedCards} size="square" variant={'gameboard'}/>
                         </Box>
                     ))}
                 </Grid>
@@ -99,7 +136,7 @@ const UnitsBoard: React.FC<IUnitsBoardProps> = ({
                 <Grid sx={styles.playerGridStyle}>
                     {playerUnits.map((card: ICardData) => (
                         <Box key={card.uuid} sx={{ flex: '0 1 auto' }}>
-                            <GameCard key={card.uuid} card={card} subcards={card.subcards} size="square" variant={'gameboard'}/>
+                            <GameCard key={card.uuid} card={card} subcards={card.subcards} capturedCards={card.capturedCards} size="square" variant={'gameboard'}/>
                         </Box>
                     ))}
                 </Grid>

--- a/src/app/_components/Gameboard/_subcomponents/UnitsBoard.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/UnitsBoard.tsx
@@ -78,8 +78,12 @@ const UnitsBoard: React.FC<IUnitsBoardProps> = ({
 
     const rawPlayerUnits = gameState?.players[connectedPlayer].cardPiles[arena];
     const rawOpponentUnits = gameState?.players[getOpponent(connectedPlayer)].cardPiles[arena];
-    const allCapturedCards = gameState?.players[connectedPlayer].cardPiles['capturedZone'];
+
+    const playerCapturedCards = gameState?.players[connectedPlayer].cardPiles['capturedZone'];
+    const opponentCapturedCards = gameState?.players[getOpponent(connectedPlayer)].cardPiles['capturedZone'];
+
     const allCardsInArena = [...rawPlayerUnits, ...rawOpponentUnits];
+    const allCapturedCards = [...playerCapturedCards, ...opponentCapturedCards];
 
     const upgradeMapping = findUpgrades(allCardsInArena);
 

--- a/src/app/_components/_sharedcomponents/Cards/CardTypes.ts
+++ b/src/app/_components/_sharedcomponents/Cards/CardTypes.ts
@@ -43,6 +43,7 @@ export interface IGameCardProps {
     variant?: 'lobby' | 'gameboard';
     disabled?: boolean;
     subcards?: ICardData[];
+    capturedCards?: ICardData[];
 }
 
 export interface ILeaderBaseCardProps {

--- a/src/app/_components/_sharedcomponents/Cards/CardTypes.ts
+++ b/src/app/_components/_sharedcomponents/Cards/CardTypes.ts
@@ -26,6 +26,7 @@ export interface ICardData {
     setId: ICardSetId;
     type: string;
     subcards?: ICardData[];
+    capturedCards?: ICardData[];
     aspects?: IAspect[];
     sentinel?: boolean;
     types?: string[];

--- a/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
@@ -22,6 +22,7 @@ const GameCard: React.FC<IGameCardProps> = ({
     size = 'standard',
     onClick,
     subcards = [],
+    capturedCards = [],
     variant,
     disabled = false,
 }) => {
@@ -346,6 +347,50 @@ const GameCard: React.FC<IGameCardProps> = ({
                     <Typography key={subcard.uuid} sx={styles.upgradeNameStyle}>{subcard.name}</Typography>
                 </Box>
             ))}
+
+            {/* Separator for Captured Cards */}
+            {capturedCards.length > 0 && (
+                <>
+                    <Typography
+                        sx={{
+                            fontSize: '11px',
+                            fontWeight: 'bold',
+                            textAlign: 'center',
+                            color: 'white',
+                            mb:'-6px',
+                            borderTop: '2px solid black',
+                            borderLeft: '2px solid black',
+                            borderRight: '2px solid black',
+                        }}
+                    >
+                        Captured
+                    </Typography>
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            justifyContent: 'center',
+                            gap: '4px',
+                            marginTop: '4px',
+                        }}
+                    >
+                        {capturedCards.map((capturedCard) => (
+                            <Box
+                                key={`captured-${capturedCard.uuid}`}
+                                sx={{
+                                    ...styles.upgradeIconLayer,
+                                    backgroundImage: `url(${cardUpgradebackground(capturedCard)})`,
+                                    bottom: 0,
+                                    position: 'relative',
+                                }}
+                            >
+                                <Typography sx={styles.upgradeNameStyle}>
+                                    {capturedCard.name}
+                                </Typography>
+                            </Box>
+                        ))}
+                    </Box>
+                </>
+            )}
         </>
     );
 };

--- a/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
@@ -290,6 +290,7 @@ const GameCard: React.FC<IGameCardProps> = ({
             fontWeight: 'bold',
             textAlign: 'center',
             color: 'white',
+            backgroundColor:'black',
             mb:'0px',
             borderTop: '2px solid black',
             borderLeft: '2px solid black',

--- a/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
@@ -284,6 +284,17 @@ const GameCard: React.FC<IGameCardProps> = ({
             height: 'auto',
             aspectRatio: '1/1',
             width: '50%'
+        },
+        capturedCardsDivider:{
+            fontSize: '11px',
+            fontWeight: 'bold',
+            textAlign: 'center',
+            color: 'white',
+            mb:'0px',
+            borderTop: '2px solid black',
+            borderLeft: '2px solid black',
+            borderRight: '2px solid black',
+            position:'relative'
         }
     }
     return (
@@ -353,42 +364,26 @@ const GameCard: React.FC<IGameCardProps> = ({
                 <>
                     <Typography
                         sx={{
-                            fontSize: '11px',
-                            fontWeight: 'bold',
-                            textAlign: 'center',
-                            color: 'white',
-                            mb:'-6px',
-                            borderTop: '2px solid black',
-                            borderLeft: '2px solid black',
-                            borderRight: '2px solid black',
+                            ...styles.capturedCardsDivider,
+                            bottom:`${otherUpgradeCards.length * 7}px`,
                         }}
                     >
                         Captured
                     </Typography>
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            justifyContent: 'center',
-                            gap: '4px',
-                            marginTop: '4px',
-                        }}
-                    >
-                        {capturedCards.map((capturedCard) => (
-                            <Box
-                                key={`captured-${capturedCard.uuid}`}
-                                sx={{
-                                    ...styles.upgradeIconLayer,
-                                    backgroundImage: `url(${cardUpgradebackground(capturedCard)})`,
-                                    bottom: 0,
-                                    position: 'relative',
-                                }}
-                            >
-                                <Typography sx={styles.upgradeNameStyle}>
-                                    {capturedCard.name}
-                                </Typography>
-                            </Box>
-                        ))}
-                    </Box>
+                    {capturedCards.map((capturedCard, index) => (
+                        <Box
+                            key={`captured-${capturedCard.uuid}`}
+                            sx={{
+                                ...styles.upgradeIconLayer,
+                                backgroundImage: `url(${cardUpgradebackground(capturedCard)})`,
+                                bottom:`${(otherUpgradeCards.length * 7 + 2) + index * 7}px`,
+                            }}
+                        >
+                            <Typography sx={styles.upgradeNameStyle}>
+                                {capturedCard.name}
+                            </Typography>
+                        </Box>
+                    ))}
                 </>
             )}
         </>


### PR DESCRIPTION
- Added the capture mechanic to the FE with a divider on the units.

GameBoard -> finds capturedUnits and adds them to their corresponding card.
GameUnit -> Added basic styling and divider for captured units.

