### PR TITLE
Fix leader background bug

### DIFF
--- a/src/app/_components/_sharedcomponents/Cards/LeaderBaseCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/LeaderBaseCard.tsx
@@ -60,7 +60,7 @@ const LeaderBaseCard: React.FC<ILeaderBaseCardProps> = ({
             position: 'absolute',
             height: '100%',
             width: '100%',
-            backgroundColor: card.exhausted ? 'rgba(0, 0, 0, 0.5)' : 'transparent',
+            backgroundColor: card.exhausted && !isDeployed ? 'rgba(0, 0, 0, 0.5)' : 'transparent',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',


### PR DESCRIPTION
The leader area background no longer turns gray when the leader unit is exhausted