### PR TITLE
Center Column Scaling changes

### DIFF
--- a/src/app/_components/Gameboard/Board/Board.tsx
+++ b/src/app/_components/Gameboard/Board/Board.tsx
@@ -53,14 +53,7 @@ const Board: React.FC<IBoardProps> = ({
             justifyContent: 'center',
             alignItems: 'center',
             position: 'relative',
-            width: {
-                xs: '8rem',
-                sm: '9rem',
-                lg: '10rem',
-                xl: '11rem',
-                xxl: '12rem',
-                xxxl: '14rem',
-            },
+            width: 'clamp(8rem, 20vh, 14rem)',
             margin: '0 1rem',
         },
         middleColumnContent: {
@@ -76,15 +69,11 @@ const Board: React.FC<IBoardProps> = ({
             flexDirection: 'column',
             alignItems: 'center',
             width: '100%',
-            gap: '10px',
+            gap: 'clamp(1px, 1.0vh, 10px)',
             padding: '0 1rem',
-            flex: 1,
-            minHeight: 0
         },
         leaderBaseWrapper: {
-            flex: 1,
             width: '100%',
-            minHeight: 0,
             display: 'flex',
             justifyContent: 'center',
         },
@@ -194,13 +183,19 @@ const Board: React.FC<IBoardProps> = ({
                             />
                         </Box>
                         <Box sx={styles.leaderBaseWrapper}>
-                            <LeaderBaseCard cardStyle={LeaderBaseCardStyle.Base} card={opponentBase}></LeaderBaseCard>
+                            <LeaderBaseCard
+                                cardStyle={LeaderBaseCardStyle.Base} 
+                                card={opponentBase}
+                            />
                         </Box>
                     </Box>
-                    <Box sx={{ flex: '0 0 60px', width: '100%' }} />
+                    <Box sx={{ flex: '0 1 60px', width: '100%' }} />
                     <Box sx={styles.leaderBaseContainer}>
                         <Box sx={styles.leaderBaseWrapper}>
-                            <LeaderBaseCard cardStyle={LeaderBaseCardStyle.Base} card={playerBase}></LeaderBaseCard>
+                            <LeaderBaseCard 
+                                cardStyle={LeaderBaseCardStyle.Base} 
+                                card={playerBase}
+                            />
                         </Box>
                         <Box sx={styles.leaderBaseWrapper}>
                             <LeaderBaseCard

--- a/src/app/_components/_sharedcomponents/Cards/LeaderBaseCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/LeaderBaseCard.tsx
@@ -100,6 +100,7 @@ const LeaderBaseCard: React.FC<ILeaderBaseCardProps> = ({
         deployedPlaceholder: {
             backgroundColor: 'transparent',
             borderRadius: '0.5rem',
+            width: '100%',
             maxHeight: '100%',
             aspectRatio: '1.39',
             cursor: 'normal',


### PR DESCRIPTION
Made some changes to the flex layout for the center column

- Leader / base card no longer cropped
- Cards scale down based on width and height (not just height)
- No more discrete levels (this is the controversial change)
- Gap inbetween the two bases will shrink if necessary