### PR TITLE
Disable done button for 0.5s on resource window

### DIFF
--- a/src/app/_components/Gameboard/_subcomponents/PlayerTray/CardActionTray.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/PlayerTray/CardActionTray.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button, Box } from '@mui/material';
 import Grid from '@mui/material/Grid2';
 import { useGame } from '@/app/_contexts/Game.context';
@@ -55,7 +55,8 @@ interface IButtonsProps {
  * CardActionTray Component
  */
 const CardActionTray: React.FC = () => {
-    const { sendGameMessage, gameState, connectedPlayer, distributionPromptData } = useGame();
+    const [ resourcePromptDoneButtonOverride, setResourcePromptDoneButtonOverride ] = useState<boolean | null>(null);
+    const { sendGameMessage, gameState, connectedPlayer, distributionPromptData, getConnectedPlayerPrompt } = useGame();
     const playerState = gameState.players[connectedPlayer];
 
     const showTrayButtons = () => {
@@ -77,10 +78,30 @@ const CardActionTray: React.FC = () => {
                     return true;
                 }
             }
+
+            // for a resource prompt, we disable the "done" button briefly to avoid double clicks
+            if (getConnectedPlayerPrompt()?.promptType === 'resource') {
+                if (resourcePromptDoneButtonOverride == null) {
+                    setResourcePromptDoneButtonOverride(true);
+                    setTimeout(() => {
+                        setResourcePromptDoneButtonOverride(false);
+                    }, 500);
+
+                    return true;
+                }
+
+                return resourcePromptDoneButtonOverride;
+            }
         }
 
         return !!button.disabled;
     };
+
+    useEffect(() => {
+        if (getConnectedPlayerPrompt()?.promptType !== 'resource') {
+            setResourcePromptDoneButtonOverride(null);
+        }
+    }, [gameState]);
 
     return (
         <Grid


### PR DESCRIPTION
We were having an issue where multiple players were reporting that the "done" button at the resource stage pops up so fast that that they were accidentally double-tapping it after hitting "pass" to end the round.

Added a timer that disables the "done" button for 0.5s whenever a new resource phase happens to prevent this.