### PR TITLE
Bug fix for spread damage icons left to right ness

### DIFF
--- a/src/app/_components/_sharedcomponents/Cards/CardValueAdjuster.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/CardValueAdjuster.tsx
@@ -24,6 +24,8 @@ const CardValueAdjuster: React.FC<ICardValueAdjusterProps> = ({ card, isIndirect
     const styles = {
         valueAdjuster: {
             display: 'flex',
+            flexDirection: 'row', // ensures left-to-right layout
+            direction: 'ltr', // <== override inherited RTL direction
             position: 'absolute',
             top: '100%',
             width: '100%',


### PR DESCRIPTION
restore the left-to-right layout of the value adjusters for spread damage