### PR TITLE
Damage adjuster button scaling

### DIFF
--- a/src/app/_components/_sharedcomponents/Cards/CardValueAdjuster.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/CardValueAdjuster.tsx
@@ -40,11 +40,12 @@ const CardValueAdjuster: React.FC<ICardValueAdjusterProps> = ({ card, isIndirect
             },
             flex: 1,
             minWidth: '50%',
+            padding: '.4rem', // overrides the variant "contained"'s padding that was breaking layout
             ':first-of-type': {
                 borderRadius: '4px 0px 0px 4px',
                 borderRight: '1px solid #404040',
             },
-            ':last-of-types': {
+            ':last-of-type': {
                 borderRadius: '0px 4px 4px 0px'
             }
         },

--- a/src/app/_components/_sharedcomponents/Cards/CardValueAdjuster.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/CardValueAdjuster.tsx
@@ -40,7 +40,7 @@ const CardValueAdjuster: React.FC<ICardValueAdjusterProps> = ({ card, isIndirect
             },
             flex: 1,
             minWidth: '50%',
-            padding: '.4rem', // overrides the variant "contained"'s padding that was breaking layout
+            padding: '.2rem', // overrides the variant "contained"'s padding that was breaking layout
             ':first-of-type': {
                 borderRadius: '4px 0px 0px 4px',
                 borderRight: '1px solid #404040',


### PR DESCRIPTION
Fixed the value adjuster buttons to scale to the width of smaller cards.  Also fixed typo that left curvature on the right side button's border on its bottom left-side edge (very subtle but you can even see easily in the iphone14 zoomed image)

Here are two visual before and after examples on different resolutions

iphone14 zoomed in (production): 
![image](https://github.com/user-attachments/assets/2dde954a-c3a0-48f7-afe3-6bdbcb80e21b)

iphone14 zoomed in (fix)
![image](https://github.com/user-attachments/assets/778e6cd8-8cd5-4e1f-b700-449f0d7a7f5b)

2560x wide board (production)
![image](https://github.com/user-attachments/assets/7c9caa5d-bfe6-4fe4-8949-41092d859a8e)

2560x wide board (fix)
![image](https://github.com/user-attachments/assets/680bb1c4-b855-4a07-b155-bcfb6e12a432)


