### PR TITLE
Better handling for dropped lobby state

### DIFF
--- a/src/app/quickGame/page.tsx
+++ b/src/app/quickGame/page.tsx
@@ -20,8 +20,10 @@ const QuickGame: React.FC = () => {
     useEffect(() => {
         if (gameState) {
             router.push('/GameBoard');
+        } else {
+            router.push('/quickGame');
         }
-    }, [router, gameState]);
+    }, [router, gameState, lobbyState]);
 
     // ------------------------STYLES------------------------//
 


### PR DESCRIPTION
Looks like the FE is potentially not transitioning correctly to the countdown screen if there is a disconnect right when the connection happens, possibly due to the lobby state getting dropped and then not listened for again.

Added some logic to check for it more aggressively, not 100% sure if this solves the issue but seems to help in some tests I tried.