### PR TITLE
Update LOF Next Set Preview format

### DIFF
--- a/src/app/_components/Lobby/_subcomponents/SetUpCard/SetUpCard.tsx
+++ b/src/app/_components/Lobby/_subcomponents/SetUpCard/SetUpCard.tsx
@@ -515,21 +515,8 @@ const SetUpCard: React.FC<ISetUpProps> = ({
             )}
             <Divider sx={{ mt: 1, borderColor: '#666', display: lobbyFormat !== 'premier' ? 'block': 'none' }} />
             <Box sx={{ display: lobbyFormat !== 'premier' ? 'block': 'none' }}>
-                <Button
-                    type="button"
-                    onClick={handleUseForceBase}
-                    variant="contained"
-                    sx={{
-                        ...styles.submitButtonStyle,
-                        mt: '1em',
-                        ml: 0
-
-                    }}
-                >
-                    Use Force Base
-                </Button>
                 <Typography sx={{ fontSize: '.9em', mt: 1 }}>
-                    Replaces your base with a Force Base of the same aspect.
+                    Official Force bases are now available on SWUDB!
                 </Typography>
 
             </Box>

--- a/src/app/_components/_sharedcomponents/QuickGameForm/QuickGameForm.tsx
+++ b/src/app/_components/_sharedcomponents/QuickGameForm/QuickGameForm.tsx
@@ -9,7 +9,7 @@ import {
     IDeckValidationFailures
 } from '@/app/_validators/DeckValidation/DeckValidationTypes';
 import { ErrorModal } from '@/app/_components/_sharedcomponents/Error/ErrorModal';
-import { SwuGameFormat } from '@/app/_constants/constants';
+import { FormatLabels, SwuGameFormat } from '@/app/_constants/constants';
 import { parseInputAsDeckData } from '@/app/_utils/checkJson';
 import { StoredDeck } from '@/app/_components/_sharedcomponents/Cards/CardTypes';
 import {
@@ -35,8 +35,8 @@ const QuickGameForm: React.FC<ICreateGameFormProps> = () => {
     const [queueState, setQueueState] = useState<boolean>(false)
     const [savedDecks, setSavedDecks] = useState<StoredDeck[]>([]);
 
-    const formatOptions = Object.values(SwuGameFormat);
-    const savedFormat = localStorage.getItem('format') !== SwuGameFormat.Premier && localStorage.getItem('format') !== SwuGameFormat.Open ? SwuGameFormat.Premier : localStorage.getItem('format') || SwuGameFormat.Premier;
+    const formatOptions = Object.values(SwuGameFormat);    
+    const savedFormat = localStorage.getItem('format') || SwuGameFormat.Premier;
     const [format, setFormat] = useState<string>(savedFormat);
 
     // error states
@@ -300,14 +300,19 @@ const QuickGameForm: React.FC<ICreateGameFormProps> = () => {
                             handleChangeFormat(e.target.value as SwuGameFormat)
                         }
                     >
-                        <MenuItem key={SwuGameFormat.Premier} value={SwuGameFormat.Premier}>
-                            {'Premier'}
-                        </MenuItem>
-                        <MenuItem key={SwuGameFormat.Open} value={SwuGameFormat.Open}>
-                            {'Open'}
-                        </MenuItem>
+                        {formatOptions.map((fmt) => (
+                            <MenuItem key={fmt} value={fmt}>
+                                {FormatLabels[fmt] || fmt}
+                            </MenuItem>
+                        ))}
                     </StyledTextField>
                 </FormControl>
+
+                <Box>
+                    <Typography variant="body1" color="yellow">
+                        Next Set Preview format is now available for Quick Match!
+                    </Typography>
+                </Box>
 
                 {/* Save Deck To Favourites Checkbox */}
                 <FormControlLabel

--- a/src/app/_constants/mockData.ts
+++ b/src/app/_constants/mockData.ts
@@ -86,12 +86,12 @@ export const playerMatches = [
 
 export const articles: IArticle[] = [
     {
-        title: 'Legends of the Force Previews',
+        title: 'Legends of the Force Previews (Update)',
         content: `
-        <p>We are excited to announce that Set 5: Legends of the Force is available for playtesting in Next Set Preview format! You can <i><b>generate a Force base of any aspect</b></i> to test your deck with by clicking the "Use Force Base" button in the lobby.</p>
-        <p>Currently matchmaking is not supported, only custom lobbies. You can also follow our progress implementing the preview cards in the <a target="_blank" href="https://karabast.net/Unimplemented" style="color:lightblue;">"Unimplemented" page</a>.</p>		<p style="margin-bottom:0;"><a target="_blank" href="https://discord.gg/hKRaqHND4v" style="color:lightblue;">Join our Discord to see the full announcement and for the latest progress updates and timelines</a>. If you have coding experience, we are always open to new contributors. Info on how to help out can also be found on <a target="_blank" href="https://discord.gg/hKRaqHND4v" style="color:lightblue;">Discord</a>.</p>
+        <p>We are excited to announce that Set 5: Legends of the Force is available for playtesting in Next Set Preview format! Force bases are now available on SWUDB, so we are supporting both quick match and custom lobbies for Next Set Preview format.</p>
+        <p>You can also follow our progress implementing the preview cards in the <a target="_blank" href="https://karabast.net/Unimplemented" style="color:lightblue;">"Unimplemented" page</a>.</p>		<p style="margin-bottom:0;"><a target="_blank" href="https://discord.gg/hKRaqHND4v" style="color:lightblue;">Join our Discord to see the full announcement and for the latest progress updates and timelines</a>. If you have coding experience, we are always open to new contributors. Info on how to help out can also be found on <a target="_blank" href="https://discord.gg/hKRaqHND4v" style="color:lightblue;">Discord</a>.</p>
 	  `,
-        date: '5/3/25',
+        date: '5/15/25',
         image: s3ImageURL('ui/quigonmaul-banner.webp'),
         imageAlt: 'Beta Announcement',
     },


### PR DESCRIPTION
Now that we have force bases, we don't need to lean on the button anymore. Updates:

- Removed the Force base button but left a text notice there to let people know why it's gone (will remove in like a week)
- Enabled Next Set Preview in quick match mode with a text note that it's available (will remove in like a week)
- Updated the news article