### PR TITLE
clear upgrade popup on click

### DIFF
--- a/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
@@ -148,6 +148,8 @@ const GameCard: React.FC<IGameCardProps> = ({
 
     const subcardClick = (subCard: ICardData) => {
         if (subCard.selectable) {
+            setAnchorElement(null);
+            setPreviewImage(null);
             sendGameMessage(['cardClicked', subCard.uuid]);
         }
     }
@@ -334,6 +336,7 @@ const GameCard: React.FC<IGameCardProps> = ({
             overflow: 'hidden',           
             color: 'black',
             textAlign: 'center', 
+            userSelect: 'none'
         },
         sentinelIcon:{
             position: 'absolute',
@@ -482,7 +485,11 @@ const GameCard: React.FC<IGameCardProps> = ({
                             {shieldCards.map((shieldCard, index) => (
                                 <Box
                                     key={`${card.uuid}-shield-${index}`}
-                                    sx={{ ...styles.shieldIcon , border: shieldCard.selectable ? `2px solid ${getBorderColor(shieldCard, connectedPlayer)}` : 'none' }}
+                                    sx={{ 
+                                        ...styles.shieldIcon, 
+                                        border: shieldCard.selectable ? `2px solid ${getBorderColor(shieldCard, connectedPlayer)}` : 'none',
+                                        cursor: shieldCard.selectable ? 'pointer' : 'normal'
+                                    }}
                                     onClick={() => subcardClick(shieldCard)}
                                 />
                             ))}
@@ -517,7 +524,7 @@ const GameCard: React.FC<IGameCardProps> = ({
                 anchorEl={anchorElement}
                 onClose={handlePreviewClose}
                 disableRestoreFocus
-                slotProps={{ paper: { sx: { backgroundColor: 'transparent' } } }}
+                slotProps={{ paper: { sx: { backgroundColor: 'transparent' }, tabIndex: -1 } }}
                 {...popoverConfig()}
             >
                 <Box sx={{ ...styles.cardPreview, backgroundImage: previewImage }} />
@@ -528,7 +535,8 @@ const GameCard: React.FC<IGameCardProps> = ({
                     key={subcard.uuid}
                     sx={{ ...styles.upgradeIcon,
                         backgroundImage: `url(${(cardUpgradebackground(subcard))})`,
-                        border: subcard.selectable ? `2px solid ${getBorderColor(subcard, connectedPlayer)}` : 'none'
+                        border: subcard.selectable ? `2px solid ${getBorderColor(subcard, connectedPlayer)}` : 'none',
+                        cursor: subcard.selectable ? 'pointer' : 'normal'
                     }}
                     onClick={() => subcardClick(subcard)}
                     onMouseEnter={handlePreviewOpen}
@@ -550,7 +558,8 @@ const GameCard: React.FC<IGameCardProps> = ({
                             sx={{
                                 ...styles.upgradeIcon,
                                 backgroundImage: `url(${cardUpgradebackground(capturedCard)})`,
-                                border: capturedCard.selectable ? `2px solid ${getBorderColor(capturedCard, connectedPlayer)}` : 'none'
+                                border: capturedCard.selectable ? `2px solid ${getBorderColor(capturedCard, connectedPlayer)}` : 'none',
+                                cursor: capturedCard.selectable ? 'pointer' : 'normal'
                             }}
                             onClick={() => subcardClick(capturedCard)}
                             onMouseEnter={handlePreviewOpen}


### PR DESCRIPTION
- Clears upgrade popup on click when it is selectable. This might introduce a popup flicker in cases where you are not selecting the upgrade for defeat but defeating an upgrade is what we're doing majority of the time when they are selectable so I think this is a fine tradeoff. 
- Update mouse styling when hovering subcards
- Remove aria warnings in console related to hover popups