### PR TITLE
Add mute chat functionality to lobby and game chat

### DIFF
--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -1,19 +1,52 @@
-import React, { useState } from 'react';
-import { Drawer, Box, Typography } from '@mui/material';
+import React, { useState, useEffect } from 'react';
+import { Drawer, Box, Typography, IconButton, Tooltip } from '@mui/material';
 import Chat from '@/app/_components/_sharedcomponents/Chat/Chat';
 import { IChatDrawerProps } from '@/app/_components/Gameboard/GameboardTypes';
 import { useGame } from '@/app/_contexts/Game.context';
+import { useUser } from '@/app/_contexts/User.context';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import ChatIcon from '@mui/icons-material/Chat';
+import BlockIcon from '@mui/icons-material/Block';
 
 const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar }) => {
     const { gameState, sendGameMessage } = useGame();
-    const [chatMessage, setChatMessage] = useState('')
+    const { user } = useUser();
+    const [chatMessage, setChatMessage] = useState('');
+    const [isMuted, setIsMuted] = useState(false);
+    
+    // Initialize mute state from user preferences
+    useEffect(() => {
+        if (user?.preferences?.muteChat !== undefined) {
+            setIsMuted(user.preferences.muteChat);
+        }
+    }, [user?.preferences?.muteChat]);
 
     const handleGameChat = () => {
         const trimmed = chatMessage.trim();
         if (!trimmed) return; // don't send empty messages
         sendGameMessage(['chat', trimmed]);
         setChatMessage('');
+    }
+    
+    const toggleMute = () => {
+        const newMuteState = !isMuted;
+        setIsMuted(newMuteState);
+        
+        // Update user preferences if authenticated
+        if (user) {
+            // Update in-memory preferences
+            user.preferences.muteChat = newMuteState;
+            
+            // Store in localStorage for dev environment
+            const storedUser = localStorage.getItem('devUser');
+            if (storedUser) {
+                const currentPrefs = user.preferences || {};
+                localStorage.setItem(`${storedUser}_preferences`, JSON.stringify({
+                    ...currentPrefs,
+                    muteChat: newMuteState
+                }));
+            }
+        }
     }
 
     // ------------------------STYLES------------------------//
@@ -48,7 +81,10 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar }) 
             sx={styles.drawerStyle}
         >
             <Box sx={styles.headerBoxStyle}>
-                <ChevronRightIcon onClick={toggleSidebar} />
+                <ChevronRightIcon 
+                    onClick={toggleSidebar} 
+                    sx={{ cursor: 'pointer' }}
+                />
                 <Typography sx={{
                     fontWeight: 'bold',
                     color: '#fff',
@@ -58,6 +94,37 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar }) 
                     transform: 'translateX(-50%)',
                     width: 'max-content',
                 }}>Chat</Typography>
+                <Tooltip title={isMuted ? "Show Player Messages" : "Hide Player Messages"}>
+                    <IconButton 
+                        onClick={toggleMute}
+                        size="small"
+                        sx={{ 
+                            color: isMuted ? '#ff5252' : '#4caf50',
+                            position: 'absolute',
+                            right: '5px',
+                            top: '1px',
+                            padding: '6px',
+                            backgroundColor: isMuted ? 'rgba(255, 82, 82, 0.1)' : 'rgba(76, 175, 80, 0.1)',
+                            '&:hover': {
+                                backgroundColor: isMuted ? 'rgba(255, 82, 82, 0.2)' : 'rgba(76, 175, 80, 0.2)',
+                            }
+                        }}
+                    >
+                        {isMuted ? (
+                            <div style={{ position: 'relative', display: 'inline-flex' }}>
+                                <ChatIcon fontSize="small" />
+                                <BlockIcon fontSize="small" style={{ 
+                                    position: 'absolute', 
+                                    top: -2, 
+                                    right: -2, 
+                                    fontSize: '1rem' 
+                                }} />
+                            </div>
+                        ) : (
+                            <ChatIcon />
+                        )}
+                    </IconButton>
+                </Tooltip>
             </Box>
 
             {/* Use the ChatComponent here */}
@@ -66,6 +133,7 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar }) 
                 chatMessage={chatMessage}
                 setChatMessage={setChatMessage}
                 handleChatSubmit={handleGameChat}
+                muteChat={isMuted}
             />
         </Drawer>
     );

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -94,7 +94,7 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar }) 
                     transform: 'translateX(-50%)',
                     width: 'max-content',
                 }}>Chat</Typography>
-                <Tooltip title={isMuted ? "Show Player Messages" : "Hide Player Messages"}>
+                <Tooltip title={isMuted ? 'Show Player Messages' : 'Hide Player Messages'}>
                     <IconButton 
                         onClick={toggleMute}
                         size="small"

--- a/src/app/_components/Lobby/SetUp/SetUp.tsx
+++ b/src/app/_components/Lobby/SetUp/SetUp.tsx
@@ -118,7 +118,7 @@ const SetUp: React.FC = ({
             <SetUpCard owner={lobbyState ? lobbyState.lobbyOwnerId === connectedPlayer : false} readyStatus={connectedUser ? connectedUser.ready : false}/>
             <Card sx={styles.mainCardStyle}>
                 <Box sx={{ position: 'relative' }}>
-                    <Tooltip title={isMuted ? "Show Player Messages" : "Hide Player Messages"}>
+                    <Tooltip title={isMuted ? 'Show Player Messages' : 'Hide Player Messages'}>
                         <IconButton 
                             onClick={toggleMute}
                             size="small"

--- a/src/app/_components/Lobby/SetUp/SetUp.tsx
+++ b/src/app/_components/Lobby/SetUp/SetUp.tsx
@@ -1,24 +1,60 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
     Card,
     Typography,
-    Box, Divider,
+    Box, 
+    Divider,
+    IconButton,
+    Tooltip
 } from '@mui/material';
 import Chat from '@/app/_components/_sharedcomponents/Chat/Chat';
 import SetUpCard from '@/app/_components/Lobby/_subcomponents/SetUpCard/SetUpCard';
 import { useGame } from '@/app/_contexts/Game.context';
-import { useRouter } from 'next/navigation'
+import { useUser } from '@/app/_contexts/User.context';
+import { useRouter } from 'next/navigation';
 import { ILobbyUserProps } from '@/app/_components/Lobby/LobbyTypes';
+import ChatIcon from '@mui/icons-material/Chat';
+import BlockIcon from '@mui/icons-material/Block';
 
 const SetUp: React.FC = ({
 }) => {
     const router = useRouter();
     const { lobbyState, sendLobbyMessage, connectedPlayer, sendMessage } = useGame();
-
+    const { user } = useUser();
+    
     // find the user
     const connectedUser = lobbyState ? lobbyState.users.find((u: ILobbyUserProps) => u.id === connectedPlayer) : null;
     // setup chat mechanics
     const [chatMessage, setChatMessage] = useState('');
+    const [isMuted, setIsMuted] = useState(false);
+    
+    // Initialize mute state from user preferences
+    useEffect(() => {
+        if (user?.preferences?.muteChat !== undefined) {
+            setIsMuted(user.preferences.muteChat);
+        }
+    }, [user?.preferences?.muteChat]);
+    
+    const toggleMute = () => {
+        const newMuteState = !isMuted;
+        setIsMuted(newMuteState);
+        
+        // Update user preferences if authenticated
+        if (user) {
+            // Update in-memory preferences
+            user.preferences.muteChat = newMuteState;
+            
+            // Store in localStorage for dev environment
+            const storedUser = localStorage.getItem('devUser');
+            if (storedUser) {
+                const currentPrefs = user.preferences || {};
+                localStorage.setItem(`${storedUser}_preferences`, JSON.stringify({
+                    ...currentPrefs,
+                    muteChat: newMuteState
+                }));
+            }
+        }
+    };
     
     const handleChatSubmit = () => {
         if (chatMessage.trim()) {
@@ -81,12 +117,47 @@ const SetUp: React.FC = ({
             <Typography sx={styles.lobbyTextStyle}>KARABAST</Typography>
             <SetUpCard owner={lobbyState ? lobbyState.lobbyOwnerId === connectedPlayer : false} readyStatus={connectedUser ? connectedUser.ready : false}/>
             <Card sx={styles.mainCardStyle}>
-                <Chat
-                    chatHistory={lobbyState ? lobbyState.gameChat?.messages : []}
-                    chatMessage={chatMessage}
-                    setChatMessage={setChatMessage}
-                    handleChatSubmit={handleChatSubmit}
-                />
+                <Box sx={{ position: 'relative' }}>
+                    <Tooltip title={isMuted ? "Show Player Messages" : "Hide Player Messages"}>
+                        <IconButton 
+                            onClick={toggleMute}
+                            size="small"
+                            sx={{ 
+                                color: isMuted ? '#ff5252' : '#4caf50',
+                                position: 'absolute',
+                                right: '5px',
+                                top: '12px',
+                                zIndex: 1,
+                                padding: '6px',
+                                backgroundColor: isMuted ? 'rgba(255, 82, 82, 0.1)' : 'rgba(76, 175, 80, 0.1)',
+                                '&:hover': {
+                                    backgroundColor: isMuted ? 'rgba(255, 82, 82, 0.2)' : 'rgba(76, 175, 80, 0.2)',
+                                }
+                            }}
+                        >
+                            {isMuted ? (
+                                <div style={{ position: 'relative', display: 'inline-flex' }}>
+                                    <ChatIcon fontSize="small" />
+                                    <BlockIcon fontSize="small" style={{ 
+                                        position: 'absolute', 
+                                        top: -2, 
+                                        right: -2, 
+                                        fontSize: '1rem' 
+                                    }} />
+                                </div>
+                            ) : (
+                                <ChatIcon />
+                            )}
+                        </IconButton>
+                    </Tooltip>
+                    <Chat
+                        chatHistory={lobbyState ? lobbyState.gameChat?.messages : []}
+                        chatMessage={chatMessage}
+                        setChatMessage={setChatMessage}
+                        handleChatSubmit={handleChatSubmit}
+                        muteChat={isMuted}
+                    />
+                </Box>
                 <Divider sx={styles.dividerStyle} />
                 <Box sx={styles.exitCard} onClick={() => handleExit()}>
                     <Typography variant="h5">

--- a/src/app/_components/_sharedcomponents/Chat/Chat.tsx
+++ b/src/app/_components/_sharedcomponents/Chat/Chat.tsx
@@ -16,6 +16,7 @@ const Chat: React.FC<IChatProps> = ({
     chatMessage,
     setChatMessage,
     handleChatSubmit,
+    muteChat = false,
 }) => {
     const { connectedPlayer, isSpectator, getOpponent } = useGame();
     const chatEndRef = useRef<HTMLDivElement | null>(null);
@@ -43,6 +44,11 @@ const Chat: React.FC<IChatProps> = ({
         try {
             let textStyle;
             let messageText;
+            
+            // Skip player chat messages if mute is enabled
+            if (message[0]?.type === 'playerChat' && muteChat) {
+                return null;
+            }
 
             if (message.hasOwnProperty('alert')) {                
                 switch (message.alert.type) {
@@ -60,7 +66,7 @@ const Chat: React.FC<IChatProps> = ({
                 }
 
                 messageText = message.alert.message;
-            } else if (message[0].type === 'playerChat') {
+            } else if (message[0]?.type === 'playerChat') {
                 return (
                     <Typography key={index} sx={styles.messageText}>
                         <span style={{ color: connectedPlayer === message[0].id ? 'var(--initiative-blue)' : 'var(--initiative-red)' }}>
@@ -180,7 +186,7 @@ const Chat: React.FC<IChatProps> = ({
 
 
             <Box sx={styles.inputContainer}>
-                {!isSpectator &&(
+                {!isSpectator && !muteChat && (
                     <TextField
                         variant="outlined"
                         placeholder="Chat"
@@ -208,6 +214,11 @@ const Chat: React.FC<IChatProps> = ({
                             },
                         }}
                     />
+                )}
+                {!isSpectator && muteChat && (
+                    <Typography sx={{ color: '#ff5252', fontSize: '0.9em', fontStyle: 'italic', textAlign: 'center', width: '100%', py: 1 }}>
+                        Player messages are disabled
+                    </Typography>
                 )}
             </Box>
         </>

--- a/src/app/_components/_sharedcomponents/Chat/ChatTypes.ts
+++ b/src/app/_components/_sharedcomponents/Chat/ChatTypes.ts
@@ -27,4 +27,5 @@ export interface IChatProps {
     opponentRoll?: number;
     setChatMessage: (message: string) => void;
     handleChatSubmit: () => void;
+    muteChat?: boolean;
 }

--- a/src/app/_contexts/User.context.tsx
+++ b/src/app/_contexts/User.context.tsx
@@ -113,7 +113,7 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({
                 provider: null,
                 providerId: null,
                 authenticated: true,
-                preferences: { cardback: undefined }
+                preferences: { cardback: undefined, muteChat: false }
             });
         } else if (user === 'ThisIsTheWay') {
             setUser({
@@ -123,7 +123,7 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({
                 provider: null,
                 providerId: null,
                 authenticated: true,
-                preferences: { cardback: undefined }
+                preferences: { cardback: undefined, muteChat: false }
             });
         }
     }

--- a/src/app/_contexts/UserTypes.ts
+++ b/src/app/_contexts/UserTypes.ts
@@ -11,6 +11,7 @@ export interface IUser {
 
 export interface Preferences {
     cardback?: string;
+    muteChat?: boolean;
 }
 
 export interface IUserContextType {


### PR DESCRIPTION
  1. Updated types:
    - Added muteChat property to the User preferences interface
    - Added muteChat prop to the Chat component interface
  2. Updated Chat component:
    - Added logic to filter out player chat messages when muted
    - Modified the input display to show a message when chat is muted
    - Hides the text input when chat is muted
  3. Added mute button to the ChatDrawer (GameBoard):
    - Added a visually distinctive button that toggles chat mute
    - Positioned at the top-right of the chat panel
    - Color-coded (green when unmuted, red when muted)
    - Used chat icon with a block overlay for muted state
  4. Added mute button to the Lobby SetUp component:
    - Implemented the same button design as the game chat
    - Positioned at the top-right of the chat panel
    - Connected to the same user preference for consistency
  5. Implemented state persistence:
    - Both components sync with user preferences
    - Preference is saved to localStorage for dev users
    - Changes in one screen are reflected in the other
