### PR TITLE
Add Text to Ability Prompt

### DIFF
--- a/src/app/_components/_sharedcomponents/Cards/CardTypes.ts
+++ b/src/app/_components/_sharedcomponents/Cards/CardTypes.ts
@@ -45,6 +45,7 @@ export interface ICardData {
     hidden?: boolean;
     isAttacker?: boolean;
     isDefender?: boolean;
+    displayText?: string;
 }
 
 export interface IServerCardData {

--- a/src/app/_components/_sharedcomponents/Popup/PopupVariant/SelectCardsPopup.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/PopupVariant/SelectCardsPopup.tsx
@@ -96,6 +96,7 @@ export const SelectCardsPopupModal = ({ data }: ButtonProps) => {
                                     onClick={() => handleCardClick(card.uuid)}
                                     disabled={clickDisabled()}
                                 />
+                                <Typography>{card.displayText}</Typography>
                                 {selectingCards && (
                                     <Box
                                         sx={{


### PR DESCRIPTION
Thrawn1 leader now shows text under card for ability popup to determine whose deck each card is on top of.