### PR TITLE
Make login announcement image into a link

### DIFF
--- a/src/app/_components/HomePage/HomePageTypes.ts
+++ b/src/app/_components/HomePage/HomePageTypes.ts
@@ -49,6 +49,7 @@ export type IArticle = {
     date: string;
     image: string;
     imageAlt: string;
+    link?: string;
 };
 
 export interface INewsItemProps {

--- a/src/app/_components/HomePage/_subcomponents/NewsItem/NewsItem.tsx
+++ b/src/app/_components/HomePage/_subcomponents/NewsItem/NewsItem.tsx
@@ -27,6 +27,7 @@ const NewsItem: React.FC<INewsItemProps> = ({ article }) => {
         newsImage: {
             borderRadius: '.5rem',
             maxHeight: '15rem',
+            cursor: article.link ? 'pointer' : 'default',
         },
     };
 
@@ -38,6 +39,7 @@ const NewsItem: React.FC<INewsItemProps> = ({ article }) => {
                 image={article.image}
                 alt={article.imageAlt}
                 sx={styles.newsImage}
+                onClick={article.link ? () => window.open(article.link, '_blank') : undefined}
             />
             <CardContent>
                 <Box sx={styles.box}>

--- a/src/app/_constants/mockData.ts
+++ b/src/app/_constants/mockData.ts
@@ -94,6 +94,7 @@ export const articles: IArticle[] = [
         date: '6/18/25',
         image: 'login_buttons.png',
         imageAlt: 'News Announcement',
+        link: '/auth'
     },
     {
         title: 'Legends of the Force Complete!',


### PR DESCRIPTION
People were trying to click on the image showing the login buttons on the announcement, adding a link to that button so it will redirect them to the login page