### PR TITLE
Orange color for resource selection and general highlighting cleanup

### DIFF
--- a/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
@@ -193,7 +193,8 @@ const GameCard: React.FC<IGameCardProps> = ({
     // Filter subcards into Shields and other upgrades
     const shieldCards = subcards.filter((subcard) => subcard.name === 'Shield');
     const otherUpgradeCards = subcards.filter((subcard) => subcard.name !== 'Shield');
-    const borderColor = getBorderColor(card, connectedPlayer, getConnectedPlayerPrompt()?.promptType, cardStyle);
+    const promptType = getConnectedPlayerPrompt()?.promptType;
+    const borderColor = getBorderColor(card, connectedPlayer, promptType, cardStyle, isOpponentEffect);
     const cardCounter = card.count || 0;
     const distributionAmount = distributionPromptData?.valueDistribution.find((item: DistributionEntry) => item.uuid === card.uuid)?.amount || 0;
     const isIndirectDamage = getConnectedPlayerPrompt()?.distributeAmongTargets?.isIndirectDamage;
@@ -222,7 +223,7 @@ const GameCard: React.FC<IGameCardProps> = ({
             backgroundRepeat: 'no-repeat',
             aspectRatio: cardStyle === CardStyle.InPlay ? '1' : '1/1.4',
             width: '100%',
-            border: borderColor && card.selected && card.zone !== 'hand' ? `4px solid ${borderColor}` : isOpponentEffect && card.selectable ? '2px solid rgba(198, 4, 198, 1)' : borderColor ? `2px solid ${borderColor}` : '2px solid transparent',
+            border: borderColor ? card.selected && card.zone !== 'hand' ? `4px solid ${borderColor}` : `2px solid ${borderColor}` : '2px solid transparent',
             boxShadow: borderColor && card.selected && card.zone !== 'hand' ? `0 0 7px 3px ${borderColor}` : 'none',
             boxSizing: 'border-box',
         },
@@ -447,7 +448,7 @@ const GameCard: React.FC<IGameCardProps> = ({
         },
         resourceIcon: {
             position: 'absolute', 
-            backgroundImage: card.selected && card.zone === 'hand' && (phase === 'setup' || phase === 'regroup') ? 'url(resource-icon.png)' : '',
+            backgroundImage: card.selected && card.zone === 'hand' && promptType === 'resource' ? 'url(resource-icon.png)' : '',
             backgroundSize: 'contain',
             backgroundRepeat: 'no-repeat',
             top: '20%',

--- a/src/app/_components/_sharedcomponents/Cards/cardUtils.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/cardUtils.tsx
@@ -26,7 +26,7 @@ export const parseSetId = (fullCardId: string) => {
 };
 
 
-export const getBorderColor = (card: ICardData, player: string, promptType: string = '', style: CardStyle = CardStyle.Plain) => {
+export const getBorderColor = (card: ICardData, player: string, promptType: string = '', style: CardStyle = CardStyle.Plain, isOpponentEffect = false) => {
     if (!card) return '';
 
     if (style === CardStyle.Prompt) {
@@ -37,8 +37,18 @@ export const getBorderColor = (card: ICardData, player: string, promptType: stri
         }
     }
 
-    if (promptType === 'resource' && card.selectable && !card.selected) {
-        return 'var(--selection-yellow)';
+    if (card.zone === 'hand' && isOpponentEffect && card.selectable && !card.selected) {
+        return 'var(--selection-purple)';
+    }
+
+    if (promptType === 'resource') {
+        if (card.selectable && !card.selected) {
+            return 'var(--selection-yellow)';
+        }
+
+        if (card.selected) {
+            return 'var(--selection-orange)';
+        }
     }
 
     if (card.selected) {

--- a/src/app/_theme/theme.ts
+++ b/src/app/_theme/theme.ts
@@ -81,6 +81,8 @@ export const theme: Theme = createTheme({
                     '--selection-green': '#72F979',
                     '--selection-red': '#FF0D0D',
                     '--selection-yellow': '#FFFE50',
+                    '--selection-orange': '#D15700',
+                    '--selection-purple': '#C604C6',
                     '--selection-blue': '#66E5FF',
                     '--selection-grey': '#9DB4A0',
                     '--initiative-blue': '#00BAFF',


### PR DESCRIPTION
A little bit of highlighting improvement since we had to do some bug fixing for the resource highlights on the BE.

Changed the highlighting border for resource selection to be orange so it better matches the color profile of the icon + gradient:

![image](https://github.com/user-attachments/assets/3ec01265-33ed-4ae0-90a6-6de575ef2a3d)


Also fixed things so that there is a border color change when selecting for an opponent's effect such as Pillage. See below how R2 is highlighted blue, used to be he would stay purple:

![image](https://github.com/user-attachments/assets/b6f02ed0-ff16-4337-84f2-ba2d2497dd1c)
