### PR TITLE
Extend action timer when bug report dialog opens

### DIFF
--- a/src/app/_components/_sharedcomponents/Preferences/PreferencesSubElementVariants/CurrentGameTab.tsx
+++ b/src/app/_components/_sharedcomponents/Preferences/PreferencesSubElementVariants/CurrentGameTab.tsx
@@ -42,8 +42,7 @@ function CurrentGameTab() {
     const handleOpenBugReport = () => {
         setBugReportOpen(true);
 
-        // extend the action timer by 60 seconds when opening the bug report dialog to give people breathing room to type
-        // TODO: reset to 60s
+        // reset the action timer when opening the bug report dialog to give people breathing room to type
         sendGameMessage(['resetActionTimer']);
     };
 

--- a/src/app/_components/_sharedcomponents/Preferences/PreferencesSubElementVariants/CurrentGameTab.tsx
+++ b/src/app/_components/_sharedcomponents/Preferences/PreferencesSubElementVariants/CurrentGameTab.tsx
@@ -15,7 +15,7 @@ function CurrentGameTab() {
     const { sendGameMessage, connectedPlayer, gameState, isSpectator } = useGame();
 
     const router = useRouter();
-    const currentPlayerName = gameState.players[connectedPlayer]?.name
+    const currentPlayerName = gameState.players[connectedPlayer]?.name;
     const [confirmConcede, setConfirmConcede] = useState<boolean>(false);
     const [bugReportOpen, setBugReportOpen] = useState<boolean>(false);
 
@@ -41,6 +41,10 @@ function CurrentGameTab() {
     // Handler for opening the bug report dialog
     const handleOpenBugReport = () => {
         setBugReportOpen(true);
+
+        // extend the action timer by 60 seconds when opening the bug report dialog to give people breathing room to type
+        // TODO: reset to 60s
+        sendGameMessage(['resetActionTimer']);
     };
 
     // Handler for closing the bug report dialog


### PR DESCRIPTION
I've noticed that bug report logs often show that the player had very little time left before being kicked for inactivity, added support for the FE to send an action timer reset request when the player opens the bug report dialog. BE PR link: https://github.com/SWU-Karabast/forceteki/pull/1506