### PR TITLE
Add support for renamed hidden icon

### DIFF
--- a/src/app/_components/_sharedcomponents/Cards/CardTypes.ts
+++ b/src/app/_components/_sharedcomponents/Cards/CardTypes.ts
@@ -60,7 +60,7 @@ export interface ICardData {
     epicActionSpent?: boolean;
     onStartingSide?: boolean;
     epicDeployActionSpent?: boolean;
-    hidden?: boolean;
+    cannotBeAttacked?: boolean;
     isAttacker?: boolean;
     isDefender?: boolean;
     displayText?: string;

--- a/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
@@ -371,7 +371,7 @@ const GameCard: React.FC<IGameCardProps> = ({
             backgroundRepeat: 'no-repeat',
             backgroundImage: 'url(/StolenIcon.png)',
         },
-        isHidden:{
+        cannotBeAttacked:{
             position: 'absolute',
             width: '28%',
             aspectRatio: '1 / 1',
@@ -504,8 +504,8 @@ const GameCard: React.FC<IGameCardProps> = ({
                 {isStolen && (
                     <Box sx={styles.stolenIcon}/>
                 )}
-                {card.hidden && (
-                    <Box sx={styles.isHidden}/>
+                {card.cannotBeAttacked && (
+                    <Box sx={styles.cannotBeAttacked}/>
                 )}
                 {cardStyle === CardStyle.InPlay && (
                     <>


### PR DESCRIPTION
We're generalizing the "hidden" icon to represent anything that can't be targeted for an attack due to an effect. The FE property was renamed, see BE PR here: https://github.com/SWU-Karabast/forceteki/pull/1508