### PR TITLE
clear distribute numbers in new action window

### DIFF
--- a/src/app/GameBoard/page.tsx
+++ b/src/app/GameBoard/page.tsx
@@ -21,6 +21,7 @@ const GameBoard = () => {
     const sidebarState = localStorage.getItem('sidebarState') !== null ? localStorage.getItem('sidebarState') === 'true' : true;
     const [sidebarOpen, setSidebarOpen] = useState(sidebarState);
     const [isPreferenceOpen, setPreferenceOpen] = useState(false);
+    const [userClosedWinScreen, setUserClosedWinScreen] = useState(false);
 
     useEffect(() => {
         if(lobbyState && !lobbyState.gameOngoing && lobbyState.gameType !== MatchType.Quick) {
@@ -29,12 +30,11 @@ const GameBoard = () => {
     }, [lobbyState, router]);
 
     useEffect(() => {
-        if (!!gameState?.winners.length) {
+        // open preferences automatically if game ended and user hasn't closed it themselves yet.
+        if (!!gameState?.winners.length && !userClosedWinScreen) {
             setPreferenceOpen(true);
-        }else{
-            setPreferenceOpen(false);
         }
-    }, [gameState?.winners]);
+    }, [gameState?.winners, userClosedWinScreen]);
 
     const toggleSidebar = () => {
         localStorage.setItem('sidebarState', !sidebarOpen ? 'true' : 'false');
@@ -42,8 +42,11 @@ const GameBoard = () => {
     }
 
     const handlePreferenceToggle = () => {
+        if(!!gameState?.winners.length) {
+            setUserClosedWinScreen(true);
+        }
         setPreferenceOpen(!isPreferenceOpen);
-    }
+    };
 
     // check if game ended already.
     const winners = !!gameState?.winners.length ? gameState.winners : undefined;

--- a/src/app/_contexts/Game.context.tsx
+++ b/src/app/_contexts/Game.context.tsx
@@ -100,9 +100,12 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
 
             const { buttons, menuTitle,promptTitle, promptUuid, selectCardMode, promptType, dropdownListOptions, perCardButtons, displayCards } = promptState;
             prunePromptStatePopups(promptUuid);
-            if (promptType === 'actionWindow') return;
+            if (promptType === 'actionWindow') {
+                clearDistributionPrompt();
+                return;
+            } 
             else if (promptType === 'distributeAmongTargets') {
-                initDistributionPrompt(promptState.distributeAmongTargets)
+                initDistributionPrompt(promptState.distributeAmongTargets);
                 return;
             }
             else if (promptType === 'displayCards') {


### PR DESCRIPTION
- Adds a clear distribute prompt when receiving an 'actionWindow' prompt to clear the state on Cancel or Undo
- Adds some logic to the preference screen to keep it from closing on state updates. It opens automatically on game win and tracks when a user closes it to prevent it from automatically popping up again on post game state updates. 