### PR TITLE
Fix deck selection dropdown memory for logged-in users

### DIFF
--- a/src/app/_components/HomePage/HomePagePlayMode.tsx
+++ b/src/app/_components/HomePage/HomePagePlayMode.tsx
@@ -25,7 +25,7 @@ const HomePagePlayMode: React.FC = () => {
     const [showMutedPopup, setShowMutedPopup] = useState<boolean>(false);
     const [moderationDays, setModerationDays] = useState<number | undefined>(undefined);
     const { user, isLoading: userLoading, updateWelcomeMessage, updateModerationSeenStatus } = useUser();
-    const { data: session, status } = useSession();
+    const { data: session } = useSession();
 
     // Deck Preferences State (moved from context)
     const [showSavedDecks, setShowSavedDecks] = useState<boolean>(() => {
@@ -50,10 +50,6 @@ const HomePagePlayMode: React.FC = () => {
     const [savedDecks, setSavedDecks] = useState<StoredDeck[]>([]);
 
     // Sync deck preferences to localStorage
-    useEffect(() => {
-        localStorage.setItem('useSavedDecks', showSavedDecks.toString());
-    }, [showSavedDecks]);
-
     useEffect(() => {
         localStorage.setItem('format', format);
     }, [format]);
@@ -94,11 +90,6 @@ const HomePagePlayMode: React.FC = () => {
         fetchDecks();
     }, [fetchDecks]);
 
-    const handleChangeSelectedDeck = useCallback((deckId: string) => {
-        setFavoriteDeck(deckId);
-        localStorage.setItem('selectedDeck', deckId);
-    }, []);
-
     const handleDeckManagement = useCallback(() => {
         router.push('/DeckPage');
     }, [router]);
@@ -129,9 +120,19 @@ const HomePagePlayMode: React.FC = () => {
         saveDeck,
     };
 
+    const handleShowSavedDecksChange = useCallback((value: boolean) => {
+        setShowSavedDecks(value);
+        localStorage.setItem('useSavedDecks', value.toString());
+    }, []);
+
+    const handleFavoriteDeckChange = useCallback((value: string) => {
+        setFavoriteDeck(value);
+        localStorage.setItem('selectedDeck', value);
+    }, []);
+
     const deckPreferencesHandlers = {
-        setShowSavedDecks: useCallback((value: boolean) => setShowSavedDecks(value), []),
-        setFavoriteDeck: useCallback((value: string) => setFavoriteDeck(value), []),
+        setShowSavedDecks: handleShowSavedDecksChange,
+        setFavoriteDeck: handleFavoriteDeckChange,
         setFormat: useCallback((value: SwuGameFormat) => setFormat(value), []),
         setSaveDeck: useCallback((value: boolean) => setSaveDeck(value), []),
     };
@@ -262,7 +263,6 @@ const HomePagePlayMode: React.FC = () => {
                                 setDeckLink={handleSetDeckLink}
                                 savedDecks={savedDecks}
                                 handleDeckManagement={handleDeckManagement}
-                                handleChangeSelectedDeck={handleChangeSelectedDeck}
                             />
                         </TabPanel>}
                         <TabPanel index={showQuickMatch ? 1 : 0} value={value}>
@@ -273,7 +273,6 @@ const HomePagePlayMode: React.FC = () => {
                                 setDeckLink={handleSetDeckLink}
                                 savedDecks={savedDecks}
                                 handleDeckManagement={handleDeckManagement}
-                                handleChangeSelectedDeck={handleChangeSelectedDeck}
                             />
                         </TabPanel>
                         {showTestGames &&

--- a/src/app/_components/HomePage/HomePagePlayMode.tsx
+++ b/src/app/_components/HomePage/HomePagePlayMode.tsx
@@ -26,66 +26,44 @@ const HomePagePlayMode: React.FC = () => {
 
     // Deck Preferences State (moved from context)
     const [showSavedDecks, setShowSavedDecks] = useState<boolean>(() => {
-        if (typeof window !== 'undefined') {
-            return localStorage.getItem('useSavedDecks') === 'true';
-        }
-        return false;
+        return localStorage.getItem('useSavedDecks') === 'true';
     });
 
     const [favoriteDeck, setFavoriteDeck] = useState<string>(() => {
-        if (typeof window !== 'undefined') {
-            return localStorage.getItem('selectedDeck') || '';
-        }
-        return '';
+        return localStorage.getItem('selectedDeck') || '';
     });
 
     const [format, setFormat] = useState<SwuGameFormat>(() => {
-        if (typeof window !== 'undefined') {
-            const stored = localStorage.getItem('format');
-            return (stored as SwuGameFormat) || SwuGameFormat.Premier;
-        }
-        return SwuGameFormat.Premier;
+        const stored = localStorage.getItem('format');
+        return (stored as SwuGameFormat) || SwuGameFormat.Premier;
     });
 
     const [deckLink, setDeckLink] = useState<string>('');
 
     const [saveDeck, setSaveDeck] = useState<boolean>(() => {
-        if (typeof window !== 'undefined') {
-            return localStorage.getItem('saveDeck') === 'true';
-        }
-        return false;
+        return localStorage.getItem('saveDeck') === 'true';
     });
 
     // Sync deck preferences to localStorage
     useEffect(() => {
-        if (typeof window !== 'undefined') {
-            localStorage.setItem('useSavedDecks', showSavedDecks.toString());
-        }
+        localStorage.setItem('useSavedDecks', showSavedDecks.toString());
     }, [showSavedDecks]);
 
     useEffect(() => {
-        if (typeof window !== 'undefined') {
-            localStorage.setItem('selectedDeck', favoriteDeck);
-        }
+        localStorage.setItem('selectedDeck', favoriteDeck);
     }, [favoriteDeck]);
 
     useEffect(() => {
-        if (typeof window !== 'undefined') {
-            localStorage.setItem('format', format);
-        }
+        localStorage.setItem('format', format);
     }, [format]);
 
     useEffect(() => {
-        if (typeof window !== 'undefined') {
-            localStorage.setItem('saveDeck', saveDeck.toString());
-        }
+        localStorage.setItem('saveDeck', saveDeck.toString());
     }, [saveDeck]);
 
     // Clear form errors function
     const clearErrors = useCallback(() => {
-        if (typeof window !== 'undefined') {
-            window.dispatchEvent(new CustomEvent('clearDeckErrors'));
-        }
+        window.dispatchEvent(new CustomEvent('clearDeckErrors'));
     }, []);
 
     const closeWelcomePopup = () => {

--- a/src/app/_components/HomePage/HomePagePlayMode.tsx
+++ b/src/app/_components/HomePage/HomePagePlayMode.tsx
@@ -43,9 +43,7 @@ const HomePagePlayMode: React.FC = () => {
 
     const [deckLink, setDeckLink] = useState<string>('');
 
-    const [saveDeck, setSaveDeck] = useState<boolean>(() => {
-        return localStorage.getItem('saveDeck') === 'true';
-    });
+    const [saveDeck, setSaveDeck] = useState<boolean>(false);
 
     const [savedDecks, setSavedDecks] = useState<StoredDeck[]>([]);
 
@@ -53,10 +51,6 @@ const HomePagePlayMode: React.FC = () => {
     useEffect(() => {
         localStorage.setItem('format', format);
     }, [format]);
-
-    useEffect(() => {
-        localStorage.setItem('saveDeck', saveDeck.toString());
-    }, [saveDeck]);
 
     const handleInitializeDeckSelection = useCallback((firstDeck: string, allDecks: StoredDeck[] | DisplayDeck[]) => {
         let selectDeck = localStorage.getItem('selectedDeck');

--- a/src/app/_components/HomePage/HomePagePlayMode.tsx
+++ b/src/app/_components/HomePage/HomePagePlayMode.tsx
@@ -72,6 +72,10 @@ const HomePagePlayMode: React.FC = () => {
         if (selectDeck !== favoriteDeck) {
             setFavoriteDeck(selectDeck);
         }
+
+        if (localStorage.getItem('useSavedDecks') == null) {
+            setShowSavedDecks(true);
+        }
     }, [favoriteDeck]);
 
     const fetchDecks = useCallback(async() => {

--- a/src/app/_components/Lobby/_subcomponents/SetUpCard/SetUpCard.tsx
+++ b/src/app/_components/Lobby/_subcomponents/SetUpCard/SetUpCard.tsx
@@ -157,8 +157,6 @@ const SetUpCard: React.FC<ISetUpProps> = ({
         // get error messages
         const deckErrors: IDeckValidationFailures = connectedUser?.deckErrors ?? [];
         const temporaryErrors: IDeckValidationFailures = connectedUser?.importDeckErrors ?? [];
-        console.log('checking deck errors', deckErrors);
-        console.log('checking import errors', temporaryErrors);
         if ((!deckErrors || Object.entries(deckErrors).length === 0) && (!temporaryErrors || Object.entries(temporaryErrors).length === 0)) {
             // No validation errors => clear any old error states
             setDeckErrorSummary(null);

--- a/src/app/_components/_sharedcomponents/ControlHub/ControlHub.tsx
+++ b/src/app/_components/_sharedcomponents/ControlHub/ControlHub.tsx
@@ -134,13 +134,6 @@ const ControlHub: React.FC<IControlHubProps> = ({
                     </NextLinkMui>
                 </Box>
             </Box>
-            <Box sx={{ mt: 1 }}>
-                <Box sx={styles.socialIconsBox}>
-                    <Typography>
-                        Looking for <NextLinkMui sx={{ color: 'white', textDecorationColor: 'white' }} href="https://petranaki.net/Arena/MainMenu.php">original Karabast</NextLinkMui>?
-                    </Typography>
-                </Box>
-            </Box>
         </Box>
     );
 };

--- a/src/app/_components/_sharedcomponents/CreateGameForm/CreateGameForm.tsx
+++ b/src/app/_components/_sharedcomponents/CreateGameForm/CreateGameForm.tsx
@@ -52,7 +52,6 @@ interface ICreateGameFormProps {
     setDeckLink: (value: string) => void;
     savedDecks: StoredDeck[];
     handleDeckManagement: () => void;
-    handleChangeSelectedDeck: (deckId: string) => void;
 }
 
 const CreateGameForm: React.FC<ICreateGameFormProps> = ({
@@ -61,14 +60,13 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
     deckLink,
     setDeckLink,
     savedDecks,
-    handleDeckManagement,
-    handleChangeSelectedDeck
+    handleDeckManagement
 }) => {
     const router = useRouter();
     const { user, isLoading: userLoading } = useUser();
     
     const { showSavedDecks, favoriteDeck, format, saveDeck } = deckPreferences;
-    const { setShowSavedDecks, setFormat, setSaveDeck } = deckPreferencesHandlers;
+    const { setShowSavedDecks, setFavoriteDeck, setFormat, setSaveDeck } = deckPreferencesHandlers;
 
     // Common State
     const [privateGame, setPrivateGame] = useState<boolean>(false);
@@ -334,7 +332,7 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
                                 select
                                 value={favoriteDeck}
                                 onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                                    handleChangeSelectedDeck(e.target.value as string)
+                                    setFavoriteDeck(e.target.value as string)
                                 }
                                 disabled={userLoading}
                                 placeholder="Favorite Decks"

--- a/src/app/_components/_sharedcomponents/CreateGameForm/CreateGameForm.tsx
+++ b/src/app/_components/_sharedcomponents/CreateGameForm/CreateGameForm.tsx
@@ -52,6 +52,7 @@ interface ICreateGameFormProps {
     setDeckLink: (value: string) => void;
     savedDecks: StoredDeck[];
     handleDeckManagement: () => void;
+    handleChangeSelectedDeck: (deckId: string) => void;
 }
 
 const CreateGameForm: React.FC<ICreateGameFormProps> = ({
@@ -60,13 +61,14 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
     deckLink,
     setDeckLink,
     savedDecks,
-    handleDeckManagement
+    handleDeckManagement,
+    handleChangeSelectedDeck
 }) => {
     const router = useRouter();
-    const { user } = useUser();
+    const { user, isLoading: userLoading } = useUser();
     
     const { showSavedDecks, favoriteDeck, format, saveDeck } = deckPreferences;
-    const { setShowSavedDecks, setFavoriteDeck, setFormat, setSaveDeck } = deckPreferencesHandlers;
+    const { setShowSavedDecks, setFormat, setSaveDeck } = deckPreferencesHandlers;
 
     // Common State
     const [privateGame, setPrivateGame] = useState<boolean>(false);
@@ -106,9 +108,6 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
     const handleChangeDeckSelectionType = (useSavedDecks: boolean) => {
         setShowSavedDecks(useSavedDecks);
         setDeckErrorSummary(null);
-    }
-    const handleSelectFavoriteDeck = (deckID: string) => {
-        setFavoriteDeck(deckID);
     }
 
     // Handle Create Game Submission
@@ -335,8 +334,9 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
                                 select
                                 value={favoriteDeck}
                                 onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                                    handleSelectFavoriteDeck(e.target.value as string)
+                                    handleChangeSelectedDeck(e.target.value as string)
                                 }
+                                disabled={userLoading}
                                 placeholder="Favorite Decks"
                             >
                                 {savedDecks.length === 0 ? (

--- a/src/app/_components/_sharedcomponents/QuickGameForm/QuickGameForm.tsx
+++ b/src/app/_components/_sharedcomponents/QuickGameForm/QuickGameForm.tsx
@@ -51,6 +51,7 @@ interface IQuickGameFormProps {
     setDeckLink: (value: string) => void;
     savedDecks: StoredDeck[];
     handleDeckManagement: () => void;
+    handleChangeSelectedDeck: (deckId: string) => void;
 }
 
 const QuickGameForm: React.FC<IQuickGameFormProps> = ({
@@ -59,10 +60,11 @@ const QuickGameForm: React.FC<IQuickGameFormProps> = ({
     deckLink,
     setDeckLink,
     savedDecks,
-    handleDeckManagement
+    handleDeckManagement,
+    handleChangeSelectedDeck
 }) => {
     const router = useRouter();
-    const { user } = useUser();
+    const { user, isLoading: userLoading } = useUser();
     
     const { showSavedDecks, favoriteDeck, format, saveDeck } = deckPreferences;
     const { setShowSavedDecks, setFavoriteDeck, setFormat, setSaveDeck } = deckPreferencesHandlers;
@@ -103,10 +105,6 @@ const QuickGameForm: React.FC<IQuickGameFormProps> = ({
     const handleChangeDeckSelectionType = (useSavedDecks: boolean) => {
         setShowSavedDecks(useSavedDecks);
         setDeckErrorSummary(null);
-    }
-
-    const handleSelectFavoriteDeck = (deckID: string) => {
-        setFavoriteDeck(deckID);
     }
 
     // Handle Create Game Submission
@@ -332,8 +330,9 @@ const QuickGameForm: React.FC<IQuickGameFormProps> = ({
                             select
                             value={favoriteDeck}
                             onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                                handleSelectFavoriteDeck(e.target.value as string)
+                                handleChangeSelectedDeck(e.target.value as string)
                             }
+                            disabled={userLoading}
                             placeholder="Favorite Decks"
                         >
                             {savedDecks.length === 0 ? (

--- a/src/app/_components/_sharedcomponents/QuickGameForm/QuickGameForm.tsx
+++ b/src/app/_components/_sharedcomponents/QuickGameForm/QuickGameForm.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FormEvent, useEffect, useState, useCallback } from 'react';
+import React, { ChangeEvent, FormEvent, useEffect, useState } from 'react';
 import {
     Box,
     Button,
@@ -23,15 +23,12 @@ import {
 import { ErrorModal } from '@/app/_components/_sharedcomponents/Error/ErrorModal';
 import { FormatLabels, SupportedDeckSources, SwuGameFormat } from '@/app/_constants/constants';
 import { parseInputAsDeckData } from '@/app/_utils/checkJson';
-import { DisplayDeck, StoredDeck } from '@/app/_components/_sharedcomponents/Cards/CardTypes';
+import { StoredDeck } from '@/app/_components/_sharedcomponents/Cards/CardTypes';
 import {
     getUserPayload,
-    retrieveDecksForUser,
     saveDeckToLocalStorage,
     saveDeckToServer
 } from '@/app/_utils/ServerAndLocalStorageUtils';
-
-import { useSession } from 'next-auth/react';
 
 interface IDeckPreferences {
     showSavedDecks: boolean;
@@ -52,13 +49,17 @@ interface IQuickGameFormProps {
     deckPreferencesHandlers: IDeckPreferencesHandlers;
     deckLink: string;
     setDeckLink: (value: string) => void;
+    savedDecks: StoredDeck[];
+    handleDeckManagement: () => void;
 }
 
 const QuickGameForm: React.FC<IQuickGameFormProps> = ({
     deckPreferences,
     deckPreferencesHandlers,
     deckLink,
-    setDeckLink
+    setDeckLink,
+    savedDecks,
+    handleDeckManagement
 }) => {
     const router = useRouter();
     const { user } = useUser();
@@ -68,10 +69,8 @@ const QuickGameForm: React.FC<IQuickGameFormProps> = ({
 
     // Common State
     const [queueState, setQueueState] = useState<boolean>(false)
-    const [savedDecks, setSavedDecks] = useState<StoredDeck[]>([]);
 
     const formatOptions = Object.values(SwuGameFormat);
-    const { data: session } = useSession(); // Get session from next-auth
 
     // error states
     const [errorModalOpen, setErrorModalOpen] = useState(false);
@@ -81,37 +80,6 @@ const QuickGameForm: React.FC<IQuickGameFormProps> = ({
     const [deckErrorDetails, setDeckErrorDetails] = useState<IDeckValidationFailures | string | undefined>(undefined);
     const [errorTitle, setErrorTitle] = useState<string>('Deck Validation Error');
     // Timer ref for clearing the inline text after 5s
-
-    const handleInitializeDeckSelection = useCallback((firstDeck: string, allDecks: StoredDeck[] | DisplayDeck[]) => {
-        let selectDeck = favoriteDeck;
-        
-        if (favoriteDeck && !allDecks.some(deck => deck.deckID === favoriteDeck)) {
-            selectDeck = '';
-        }
-
-        if (!selectDeck) {
-            selectDeck = firstDeck || '';
-        }
-
-        if (selectDeck !== favoriteDeck) {
-            setFavoriteDeck(selectDeck);
-        }
-    }, [favoriteDeck, setFavoriteDeck]);
-
-    // Load saved decks from localStorage
-    const fetchDecks = useCallback(async () => {
-        try {
-            await retrieveDecksForUser(session?.user, user,{ setDecks: setSavedDecks, setFirstDeck: handleInitializeDeckSelection });
-        }catch (err) {
-            console.log(err);
-            alert('Server error when fetching decks');
-        }
-    }, [session?.user, user, handleInitializeDeckSelection]);
-
-    // Load saved decks when component mounts
-    useEffect(() => {
-        fetchDecks();
-    }, [fetchDecks]);
 
     // Listen for tab change events to clear errors
     useEffect(() => {
@@ -127,10 +95,6 @@ const QuickGameForm: React.FC<IQuickGameFormProps> = ({
             window.removeEventListener('clearDeckErrors', handleClearErrors);
         };
     }, []);
-
-    const handleDeckManagement = () => {
-        router.push('/DeckPage');
-    }
 
     const handleChangeFormat = (format: SwuGameFormat) => {
         setFormat(format);
@@ -267,7 +231,7 @@ const QuickGameForm: React.FC<IQuickGameFormProps> = ({
             setDeckErrorDetails(undefined);
             setErrorTitle('Deck Validation Error');
             router.push('/quickGame');
-        } catch (error) {
+        } catch {
             setQueueState(false);
             setDeckErrorSummary('Error creating game.');
             setDeckErrorDetails(undefined);

--- a/src/app/_components/_sharedcomponents/QuickGameForm/QuickGameForm.tsx
+++ b/src/app/_components/_sharedcomponents/QuickGameForm/QuickGameForm.tsx
@@ -51,7 +51,6 @@ interface IQuickGameFormProps {
     setDeckLink: (value: string) => void;
     savedDecks: StoredDeck[];
     handleDeckManagement: () => void;
-    handleChangeSelectedDeck: (deckId: string) => void;
 }
 
 const QuickGameForm: React.FC<IQuickGameFormProps> = ({
@@ -60,8 +59,7 @@ const QuickGameForm: React.FC<IQuickGameFormProps> = ({
     deckLink,
     setDeckLink,
     savedDecks,
-    handleDeckManagement,
-    handleChangeSelectedDeck
+    handleDeckManagement
 }) => {
     const router = useRouter();
     const { user, isLoading: userLoading } = useUser();
@@ -330,7 +328,7 @@ const QuickGameForm: React.FC<IQuickGameFormProps> = ({
                             select
                             value={favoriteDeck}
                             onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                                handleChangeSelectedDeck(e.target.value as string)
+                                setFavoriteDeck(e.target.value as string)
                             }
                             disabled={userLoading}
                             placeholder="Favorite Decks"

--- a/src/app/_contexts/User.context.tsx
+++ b/src/app/_contexts/User.context.tsx
@@ -16,6 +16,7 @@ import { getUserFromServer } from '@/app/_utils/ServerAndLocalStorageUtils';
 const UserContext = createContext<IUserContextType>({
     user: null,
     anonymousUserId: null,
+    isLoading: true,
     login: () => {},
     devLogin: () => {},
     logout: () => {},
@@ -30,7 +31,7 @@ const UserContext = createContext<IUserContextType>({
 export const UserProvider: React.FC<{ children: ReactNode }> = ({
     children,
 }) => {
-    const { data: session, update } = useSession(); // Get session from next-auth
+    const { data: session, update, status } = useSession(); // Get session from next-auth
     const [user, setUser] = useState<IUserContextType['user']>(null);
     const [anonymousUserId, setAnonymousUserId] = useState<string | null>(null);
     const router = useRouter();
@@ -224,7 +225,20 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({
     }
 
     return (
-        <UserContext.Provider value={{ user, anonymousUserId, login, devLogin, logout, updateUsername, updateWelcomeMessage, updateNeedsUsernameChange, updateUserPreferences, updateSwuStatsRefreshToken, updateModerationSeenStatus }}>
+        <UserContext.Provider value={{ 
+            user,
+            anonymousUserId,
+            isLoading: status === 'loading' || (status === 'authenticated' && user == null),
+            login,
+            devLogin,
+            logout,
+            updateUsername,
+            updateWelcomeMessage,
+            updateNeedsUsernameChange,
+            updateUserPreferences,
+            updateSwuStatsRefreshToken,
+            updateModerationSeenStatus
+        }}>
             {children}
         </UserContext.Provider>
     );

--- a/src/app/_contexts/UserTypes.ts
+++ b/src/app/_contexts/UserTypes.ts
@@ -56,6 +56,7 @@ export interface IPreferences {
 export interface IUserContextType {
     user: IUser | null;
     anonymousUserId: string | null;
+    isLoading: boolean;
     login: (provider: 'google' | 'discord') => void;
     devLogin: (user: 'Order66' | 'ThisIsTheWay') => void;
     logout: () => void;

--- a/src/app/api/swustats/route.ts
+++ b/src/app/api/swustats/route.ts
@@ -31,8 +31,6 @@ const CONFIG = {
 export async function GET(req: Request) {
     const code = new URL(req.url).searchParams.get('code');
     // we log the request to see
-    console.log('[DEBUG]: request from swustats:',req);
-    console.log('[DEBUG]: url environment:', process.env.NEXTAUTH_URL);
     if (!code) {
         console.error('[SWU Stats] Missing authorization code');
         return NextResponse.redirect(new URL(CONFIG.redirects.error, CONFIG.returnUrl));
@@ -59,9 +57,6 @@ async function fetchSwuStatsTokens(code: string): Promise<ISwuStatsToken> {
     const redirectUri = process.env.NODE_ENV === 'development' ?
         'http://localhost:3000/api/swustats' :
         'https://karabast.net/api/swustats'
-    console.log('[DEBUG] CLIENT_ID exists:', !!process.env.SWUSTATS_CLIENT_ID);
-    console.log('[DEBUG] CLIENT_SECRET exists:', !!process.env.SWUSTATS_CLIENT_SECRET);
-    console.log('[DEBUG] NODE_ENV:', process.env.NODE_ENV);
     
     if (!clientId || !clientSecret) {
         throw new Error('SWU Stats client credentials are not configured');


### PR DESCRIPTION
The selected deck from the saved decks dropdown was not persisting across refreshes if a user is logged in. This ended up being an issue with the context thrashing a bit while the user loads.

Fixed the issue and hit a few other small improvements:
- Consolidated the remaining duplicated code from the tabs up to HomePagePlayMode
- Removed some debug console logs from previous PRs
- Removed the "old karabast" link as suggested by ninin and Oot
- Updated the new deck / saved deck radio button to default to "saved deck" on first load if saved decks are available