### PR TITLE
Updated the token cards to stitch the bottom border in their truncated form

### DIFF
--- a/src/app/_utils/s3Utils.ts
+++ b/src/app/_utils/s3Utils.ts
@@ -26,9 +26,11 @@ export const s3CardImageURL = (card: ICardData | IServerCardData | ISetCode | IP
     const setId = isGameOrSetCard ? card.setId : parseSetId(card.id);
     // check if the card has a type
     const cardType = 'type' in card ? card.type || (Array.isArray(card.types) ? card.types.join() : card.types) : 'types' in card ? card.types : undefined;
-    const tokenIds = ['3941784506', '3463348370', '7268926664', '9415311381', '8752877738', '2007868442']
+    const format = cardStyle === CardStyle.InPlay ? 'truncated' : 'standard';
+
+    const tokenIds = ['3941784506', '3463348370', '7268926664', '9415311381', '8752877738', '2007868442','6665455613']
     if (cardType?.includes('token') || (card.id && tokenIds.includes(card.id))) {
-        return s3ImageURL(`cards/_tokens/${card.id}.webp`);
+        return s3ImageURL(`cards/_tokens/${format}/${card.id}.webp`);
     }
 
     let cardNumber = setId.number.toString().padStart(3, '0')
@@ -40,7 +42,6 @@ export const s3CardImageURL = (card: ICardData | IServerCardData | ISetCode | IP
     if (cardType === 'leader' && 'onStartingSide' in card && !card.onStartingSide) {
         cardNumber += '2';
     }
-    const format = cardStyle === CardStyle.InPlay ? 'truncated' : 'standard';
 
     return s3ImageURL(`cards/${setId.set}/${format}/large/${cardNumber}.webp?v=2`);
 };

--- a/src/app/_utils/s3Utils.ts
+++ b/src/app/_utils/s3Utils.ts
@@ -28,7 +28,7 @@ export const s3CardImageURL = (card: ICardData | IServerCardData | ISetCode | IP
     const cardType = 'type' in card ? card.type || (Array.isArray(card.types) ? card.types.join() : card.types) : 'types' in card ? card.types : undefined;
     const format = cardStyle === CardStyle.InPlay ? 'truncated' : 'standard';
 
-    const tokenIds = ['3941784506', '3463348370', '7268926664', '9415311381', '8752877738', '2007868442','6665455613']
+    const tokenIds = ['3941784506', '3463348370', '7268926664', '9415311381', '8752877738', '2007868442', '6665455613']
     if (cardType?.includes('token') || (card.id && tokenIds.includes(card.id))) {
         return s3ImageURL(`cards/_tokens/${format}/${card.id}.webp`);
     }


### PR DESCRIPTION
Updated s3Utils to pull a standard or truncated version of the token cards.  Used Mobyus's cards to create a stitched version for the game cards that have a bottom border

Two examples with hover on the token

<img width="520" height="459" alt="image" src="https://github.com/user-attachments/assets/5551d6aa-30a3-4f8f-be88-3a4aa2541727" />

<img width="495" height="412" alt="image" src="https://github.com/user-attachments/assets/35f5c2d2-e330-4b7f-8026-be64caea06e5" />


New s3 directory structure for tokens:
standard: what we were currently using
truncated: the new truncated images (using the same python scripts)
custom: "resized" images using the python script from Mobyus's contributions in the channel

<img width="1782" height="389" alt="image" src="https://github.com/user-attachments/assets/04a826c5-c53a-4f64-92f5-6c2dc37bacfa" />
