### PR TITLE
set leaders to only show up in filter when their ongoinggames > 0; al…

### DIFF
--- a/src/app/_components/HomePage/_subcomponents/GamesInProgress/GamesInProgress.tsx
+++ b/src/app/_components/HomePage/_subcomponents/GamesInProgress/GamesInProgress.tsx
@@ -150,6 +150,12 @@ const GamesInProgress: React.FC = () => {
         );
     };
 
+    const noGamesText: () => string = () => {
+        if (!leaderData) return 'Loading leaders...';
+        if (gamesData?.numberOfOngoingGames === 0) return 'No games found...';
+        return 'No leader(s) found with that name...';
+    }
+
     const styles = {
         headerBox: {
             display: 'flex',
@@ -254,7 +260,7 @@ const GamesInProgress: React.FC = () => {
                     onChange={(_, newValue) => setSortByLeader(newValue ? newValue.id : null)}
                     isOptionEqualToValue={(option, value) => option.id === value.id}
                     sx={styles.filterByLeaderAutoComplete}
-                    noOptionsText='No Leaders Found...'
+                    noOptionsText={noGamesText()}
                     renderInput={(params) => (
                         <TextField
                             {...params}


### PR DESCRIPTION
…so update leader filter logic

Looks identical to before, but I removed the bad react hook I had before and added the logic to the ongoingGames call (this seems much more reasonable on my part).