### PR TITLE
Use system time for tracking heartbeats

### DIFF
--- a/src/app/_contexts/Game.context.tsx
+++ b/src/app/_contexts/Game.context.tsx
@@ -260,8 +260,8 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
             }
         })
         
-        newSocket.on('queueHeartbeat', (timestamp) => {
-            setLastQueueHeartbeat(timestamp);
+        newSocket.on('queueHeartbeat', () => {
+            setLastQueueHeartbeat(Date.now());
         });
 
         newSocket.on('bugReportResult', (result: any) => {


### PR DESCRIPTION
We're using a mix of server time and client time for tracking heartbeats. This can cause issues if the server and client clocks differ. Specifically, if the client clock is ahead of the server, we detect a false positive of client timing out while queuing for a game.