### PR TITLE
Fix: disable minus button when counter is at 0 in distribution prompt

### DIFF
--- a/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
@@ -65,12 +65,6 @@ const GameCard: React.FC<IGameCardProps> = ({
             return;
         }
 
-        // Check if we're hovering over CardValueAdjuster
-        const eventTarget = event.target as HTMLElement;
-        if (eventTarget.closest('[data-value-adjuster]')) {
-            return;
-        }
-
         hoverTimeout.current = window.setTimeout(() => {
             setAnchorElement(target);
             setPreviewImage(`url(${imageUrl})`);

--- a/src/app/_components/_sharedcomponents/Cards/LeaderBaseCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/LeaderBaseCard.tsx
@@ -50,13 +50,6 @@ const LeaderBaseCard: React.FC<ILeaderBaseCardProps> = ({
         const target = event.currentTarget;
         const imageUrl = target.getAttribute('data-card-url');
         if (!imageUrl) return;
-
-        // Check if we're hovering over CardValueAdjuster
-        const eventTarget = event.target as HTMLElement;
-        if (eventTarget.closest('[data-value-adjuster]')) {
-            return;
-        }
-
         hoverTimeout.current = window.setTimeout(() => {
             setAnchorElement(target);
             setPreviewImage(`url(${imageUrl})`);


### PR DESCRIPTION
Addresses user confusion in healing distribution by disabling the minus button when the counter is at zero, providing a visual cue to use the plus button for adding healing instead. Attempted to follow style conventions and minimize redundancy.