### PR TITLE
Implement off-board cancel support in GameCard component

### DIFF
--- a/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
@@ -446,7 +446,7 @@ const GameCard: React.FC<IGameCardProps> = ({
             aspectRatio: '1 / 1',
             top: '32%',
             right: cardStyle === CardStyle.InPlay ? '-4%' : 'auto',
-            left: cardStyle === CardStyle.InPlay ? 'auto' : '-4%',
+            left: cardStyle === CardStyle.InPlay ? 'auto' : '1%',
             backgroundSize: 'contain',
             backgroundRepeat: 'no-repeat',
             backgroundImage: 'url(/BlankIcon.png)',


### PR DESCRIPTION
This looks to be a simple fix, the one thing I noticed was that the cancel icon doesn't render for the top card of the discard zone - when you click into the discard zone it shows up, though, so I'm not sure how big of an issue this is.