### PR TITLE
Fix lobby sideboarding errors

### DIFF
--- a/src/app/_components/Lobby/_subcomponents/SetUpCard/SetUpCard.tsx
+++ b/src/app/_components/Lobby/_subcomponents/SetUpCard/SetUpCard.tsx
@@ -219,10 +219,16 @@ const SetUpCard: React.FC<ISetUpProps> = ({
             setBlockError(false);
         }
         if (temporaryErrors && !deckImportErrorsSeen) {
+            if (hasSomeNonSideboardingErrors(temporaryErrors)) {
             // Only 'notImplemented' or no errors => clear them out
-            setDisplayError(true);
-            setError('Couldn\'t import. Deck is invalid.',temporaryErrors, 'Deck Validation Error', 'error');
-            setModalOpen(true);
+                setDisplayError(true);
+                setError('Couldn\'t import. Deck is invalid.',temporaryErrors, 'Deck Validation Error', 'error');
+                setModalOpen(true);
+            } else {
+                setDisplayError(true);
+                setError('Sideboarding restrictions not met');
+                setModalOpen(false);
+            }
         }
     }, [connectedUser]);
 


### PR DESCRIPTION
There were a couple of unexpected behaviors around main board size limits in the lobby:

1. If a user loaded a deck with 50 cards in main but then briefly dropped below 50 due to sideboarding, an error would pop up. Looks like this was due to a faulty null check value.

2. Users could not load decks with less than 50 cards in MB, even if there would be enough SB cards to set up a legal deck. This required some changes on both sides, but now it will show error text but not pop up anything up. See example below.

BE PR: https://github.com/SWU-Karabast/forceteki/pull/1959

<img width="1843" height="804" alt="image" src="https://github.com/user-attachments/assets/f8c3ece1-97a1-4725-b7de-c088616dab00" />
