### PR TITLE
Add support for KyberDecks deck imports

### DIFF
--- a/src/app/_constants/constants.ts
+++ b/src/app/_constants/constants.ts
@@ -119,6 +119,8 @@ export const SupportedDeckSources = Object.values(DeckSource)
                 return 'protectthepod.com';
             case DeckSource.SWUForge:
                 return 'swuforge.com';
+            case DeckSource.KyberDecks:
+                return 'kyberdecks.com';
             default:
                 return source;
         }

--- a/src/app/_utils/checkJson.ts
+++ b/src/app/_utils/checkJson.ts
@@ -221,7 +221,8 @@ export const parseInputAsDeckData = (input: string): {
         input.includes('swumetastats.com') ||
         input.includes('my-swu.com') ||
         input.includes('protectthepod.com') ||
-        input.includes('swuforge.com')
+        input.includes('swuforge.com') ||
+        input.includes('kyberdecks.com')
     ) {
         return { type: 'url', data: null };
     }

--- a/src/app/_utils/fetchDeckData.ts
+++ b/src/app/_utils/fetchDeckData.ts
@@ -21,6 +21,7 @@ export enum DeckSource {
     MySWU = 'MySWU',
     ProtectThePod = 'ProtectThePod',
     SWUForge = 'SWUForge',
+    KyberDecks = 'KyberDecks',
 }
 
 export interface IDeckData {
@@ -87,6 +88,8 @@ export const determineDeckSource = (deckLink: string): DeckSource => {
         return DeckSource.ProtectThePod;
     } else if (deckLink.includes('swuforge.com')) {
         return DeckSource.SWUForge;
+    } else if (deckLink.includes('kyberdecks.com')) {
+        return DeckSource.KyberDecks;
     }
 
     // Default fallback

--- a/src/app/api/swudbdeck/route.ts
+++ b/src/app/api/swudbdeck/route.ts
@@ -274,7 +274,7 @@ export async function GET(req: Request) {
                 );
             }
 
-            const apiUrl = `https://wvwxihpohprhejxonqlc.supabase.co/functions/v1/export-deck-json?id=${deckId}`;
+            const apiUrl = `https://exportdeck.kyberdecks.com/api/deck-export?id=${deckId}`;
 
             response = await fetch(apiUrl, { method: 'GET', cache: 'no-store' });
             if (!response.ok) {

--- a/src/app/api/swudbdeck/route.ts
+++ b/src/app/api/swudbdeck/route.ts
@@ -259,6 +259,32 @@ export async function GET(req: Request) {
                 console.error('SWUForge API error:', response.statusText);
                 throw new Error(`SWUForge API error: ${response.statusText}`);
             }
+        } else if (deckLink.includes('kyberdecks.com')) {
+            // Deck Links in the form: https://kyberdecks.com/decks/${deckId}
+            const match = deckLink.match(/\/decks\/([^\/]+)\/?$/);
+            const deckId = match ? match[1] : null;
+            if (deckId != null) deckIdentifier = deckId;
+            deckSource = DeckSource.KyberDecks;
+
+            if (!deckId) {
+                console.error('Error: Invalid deckLink format');
+                return NextResponse.json(
+                    { error: 'Invalid deckLink format' },
+                    { status: 400 }
+                );
+            }
+
+            const apiUrl = `https://wvwxihpohprhejxonqlc.supabase.co/functions/v1/export-deck-json?id=${deckId}`;
+
+            response = await fetch(apiUrl, { method: 'GET', cache: 'no-store' });
+            if (!response.ok) {
+                if (response.status === 404) {
+                    return NextResponse.json({ error: 'Deck not found. Make sure the deck exists on kyberdecks.com.' }, { status: 404 });
+                }
+
+                console.error('KyberDecks API error:', response.statusText);
+                throw new Error(`KyberDecks API error: ${response.statusText}`);
+            }
         } else {
             console.error('Error: Deckbuilder not supported');
             return NextResponse.json({ error: 'Deckbuilder not supported' }, { status: 400 });


### PR DESCRIPTION
I am currently developing [KyberDecks](https://kyberdecks.com), a new deck builder and community platform for SWU. 

We are currently in beta testing and would love to allow our users to test their decks on Karabast directly!

This PR adds `kyberdecks.com` to the list of supported deck sources.

**Changes included in this PR:**

- Added `KyberDecks` to the [DeckSource] enum in [fetchDeckData.ts]

- Added the `kyberdecks.com` domain to [constants.ts[ and [checkJson.ts[

- Added a URL parser in [route.ts] that safely extracts the deck UUID and fetches the JSON payload from our public Supabase Edge Function (`/functions/v1/export-deck-json?id={deckId}`).

Our JSON export format is structured exactly 1-to-1 with the DeckJSON interface you already use (including support for `secondleader` in Twin Suns). 

Let me know if there's anything else I can do to help or if you'd like me to make any adjustments so this aligns with your backend standards. 

Thanks for reviewing!