### PR TITLE
Disclose Mock Delay UI

### DIFF
--- a/src/app/_components/Gameboard/_subcomponents/PlayerTray/CardActionTray.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/PlayerTray/CardActionTray.tsx
@@ -84,16 +84,8 @@ const pulseRedBorder = keyframes`
 `;
 
 const mockDelayDrain = keyframes`
-  0% {
-    border-color: rgba(57, 255, 20, 0.9);
-    box-shadow: 0 0 12px rgba(57, 255, 20, 0.8), inset 0 0 4px rgba(57, 255, 20, 0.3);
-    background-position: 100% center;
-  }
-  100% {
-    border-color: rgba(57, 255, 20, 0.1);
-    box-shadow: 0 0 2px rgba(57, 255, 20, 0.1);
-    background-position: 0% center;
-  }
+  0%   { clip-path: inset(0 0% 0 0 round 1rem); }
+  100% { clip-path: inset(0 100% 0 0 round 1rem); }
 `;
 
 const createStyles = (isPortrait: boolean) => ({
@@ -257,14 +249,21 @@ const PromptButton: React.FC<IPromptButtonProps> = ({ button, sendGameMessage, d
     const styles = createStyles(isPortrait);
     
     const actionTrayStyles = (button: IButtonsProps, disabled = false, isMockDelay = false, delayMs = 1000) => {
-        if (isMockDelay && (button.arg === 'pass' || button.arg === 'passAbility')) {
+        if (isMockDelay) {
             return disabled ? {} : {
-                background: `linear-gradient(rgb(29, 29, 29), #0a2e0a) padding-box,
-            linear-gradient(to right, rgba(57,255,20,0.9) 0%, rgba(57,255,20,0.1) 100%) border-box`,
-                backgroundSize: '200% 100%',
-                '&:not(:disabled)': {
+                background: `linear-gradient(rgb(29, 29, 29), #3d3a0a) padding-box,
+                    linear-gradient(to top, #b3a81c, #3d3a0a) border-box`,
+                border: '1px solid rgba(204, 172, 0, 0.5)',
+                position: 'relative',
+                '&::before': {
+                    content: '""',
+                    position: 'absolute',
+                    inset: '-6px',
+                    borderRadius: 'inherit',
+                    border: '2px solid rgba(57,255,20,0.85)',
+                    boxShadow: '0 0 16px 6px rgba(57,255,20,0.7), 0 0 40px 12px rgba(57,255,20,0.35), 0 0 70px 20px rgba(57,255,20,0.15)',
                     animation: `${mockDelayDrain} ${delayMs}ms linear forwards`,
-                    border: '2px solid rgba(57, 255, 20, 0.9)',
+                    pointerEvents: 'none',
                 },
             };
         }

--- a/src/app/_components/Gameboard/_subcomponents/PlayerTray/CardActionTray.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/PlayerTray/CardActionTray.tsx
@@ -88,6 +88,7 @@ const mockDelayDrain = keyframes`
   100% { clip-path: inset(0 100% 0 0 round 1rem); }
 `;
 
+
 const createStyles = (isPortrait: boolean) => ({
     actionContainer: {
         ...debugBorder('yellow'),
@@ -255,13 +256,21 @@ const PromptButton: React.FC<IPromptButtonProps> = ({ button, sendGameMessage, d
                     linear-gradient(to top, #b3a81c, #3d3a0a) border-box`,
                 border: '1px solid rgba(204, 172, 0, 0.5)',
                 position: 'relative',
+                // Single glowing border that drains right-to-left with the timer.
+                // filter: drop-shadow() is processed AFTER clip-path, so the glow
+                // only radiates from the still-visible portion of the border.
                 '&::before': {
                     content: '""',
                     position: 'absolute',
-                    inset: '-6px',
+                    inset: '-4px',
                     borderRadius: 'inherit',
-                    border: '2px solid rgba(57,255,20,0.85)',
-                    boxShadow: '0 0 16px 6px rgba(57,255,20,0.7), 0 0 40px 12px rgba(57,255,20,0.35), 0 0 70px 20px rgba(57,255,20,0.15)',
+                    border: '3px solid rgba(57, 255, 20, 0.95)',
+                    filter: [
+                        'drop-shadow(0 0 4px rgba(57,255,20,1))',
+                        'drop-shadow(0 0 10px rgba(57,255,20,0.9))',
+                        'drop-shadow(0 0 22px rgba(57,255,20,0.7))',
+                        'drop-shadow(0 0 45px rgba(57,255,20,0.45))',
+                    ].join(' '),
                     animation: `${mockDelayDrain} ${delayMs}ms linear forwards`,
                     pointerEvents: 'none',
                 },

--- a/src/app/_components/Gameboard/_subcomponents/PlayerTray/CardActionTray.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/PlayerTray/CardActionTray.tsx
@@ -83,6 +83,19 @@ const pulseRedBorder = keyframes`
   }
 `;
 
+const mockDelayDrain = keyframes`
+  0% {
+    border-color: rgba(57, 255, 20, 0.9);
+    box-shadow: 0 0 12px rgba(57, 255, 20, 0.8), inset 0 0 4px rgba(57, 255, 20, 0.3);
+    background-position: 100% center;
+  }
+  100% {
+    border-color: rgba(57, 255, 20, 0.1);
+    box-shadow: 0 0 2px rgba(57, 255, 20, 0.1);
+    background-position: 0% center;
+  }
+`;
+
 const createStyles = (isPortrait: boolean) => ({
     actionContainer: {
         ...debugBorder('yellow'),
@@ -155,11 +168,14 @@ const CardActionTray: React.FC = () => {
     const playerState = gameState.players[connectedPlayer];
 
     const styles = createStyles(isPortrait);
+    const isMockDelay = playerState.promptState.promptType === 'discloseMockDelay';
+    const mockDelayMs = playerState.promptState.delayMs ?? 1000;
 
     const showTrayButtons = () => {
         if ( playerState.promptState.promptType === 'actionWindow' ||
              playerState.promptState.promptType === 'resource' ||
              playerState.promptState.promptType === 'distributeAmongTargets' ||
+             playerState.promptState.promptType === 'discloseMockDelay' ||
              (hasSelectedCards(gameState, ['groundArena','spaceArena']) && playerState.promptState.buttons?.length == 2) ||
              !!playerState.promptState.selectCardMode === true ) {
             return true;
@@ -217,6 +233,8 @@ const CardActionTray: React.FC = () => {
                   button={button}
                   sendGameMessage={sendGameMessage}
                   disabled={buttonDisabled(button)}
+                  isMockDelay={isMockDelay}
+                  delayMs={mockDelayMs}
               />
           ))}
             </Box>
@@ -229,14 +247,28 @@ interface IPromptButtonProps {
     button: IButtonsProps;
     sendGameMessage: (args: [string, string, string]) => void;
     disabled?: boolean;
+    isMockDelay?: boolean;
+    delayMs?: number;
 }
 
 
-const PromptButton: React.FC<IPromptButtonProps> = ({ button, sendGameMessage, disabled }) => {
+const PromptButton: React.FC<IPromptButtonProps> = ({ button, sendGameMessage, disabled, isMockDelay = false, delayMs = 1000 }) => {
     const { isPortrait } = useScreenOrientation();
     const styles = createStyles(isPortrait);
     
-    const actionTrayStyles = (button: IButtonsProps, disabled = false) => {
+    const actionTrayStyles = (button: IButtonsProps, disabled = false, isMockDelay = false, delayMs = 1000) => {
+        if (isMockDelay && (button.arg === 'pass' || button.arg === 'passAbility')) {
+            return disabled ? {} : {
+                background: `linear-gradient(rgb(29, 29, 29), #0a2e0a) padding-box,
+            linear-gradient(to right, rgba(57,255,20,0.9) 0%, rgba(57,255,20,0.1) 100%) border-box`,
+                backgroundSize: '200% 100%',
+                '&:not(:disabled)': {
+                    animation: `${mockDelayDrain} ${delayMs}ms linear forwards`,
+                    border: '2px solid rgba(57, 255, 20, 0.9)',
+                },
+            };
+        }
+
         if (button.arg === 'claimInitiative' || button.text === 'Draw') {
             return disabled ? {} : {
                 background: `linear-gradient(rgb(29, 29, 29), #0a3b4d) padding-box, 
@@ -313,7 +345,7 @@ const PromptButton: React.FC<IPromptButtonProps> = ({ button, sendGameMessage, d
     return (
         <Button
             variant="contained"
-            sx={{ ...styles.promptButton, ...actionTrayStyles(button, button.disabled) }}
+            sx={{ ...styles.promptButton, ...actionTrayStyles(button, button.disabled, isMockDelay, delayMs) }}
             onClick={() => sendGameMessage([button.command, button.arg, button.uuid])}
             disabled={disabled}
         >

--- a/src/app/_components/_sharedcomponents/Popup/Popup.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/Popup.tsx
@@ -2,7 +2,7 @@
 import { PopupData, PopupType, usePopup } from '@/app/_contexts/Popup.context';
 import { Box, SxProps, Theme } from '@mui/material';
 import React from 'react';
-import { DefaultPopup, DropdownPopup, PilePopup, SelectCardsPopup } from './Popup.types';
+import { DefaultPopup, DropdownPopup, PilePopup, SelectCardsPopup, DiscloseMockDelayPopup } from './Popup.types';
 import { DefaultPopupModal } from './PopupVariant/DefaultPopup';
 import { PilePopupModal } from './PopupVariant/PilePopup';
 import { SelectCardsPopupModal } from './PopupVariant/SelectCardsPopup';
@@ -10,6 +10,7 @@ import { contentStyle } from './Popup.styles';
 import { useGame } from '@/app/_contexts/Game.context';
 import { DropdownPopupModal } from './PopupVariant/DropdownPopup';
 import { LeaveGamePopupModule } from '@/app/_components/_sharedcomponents/Popup/PopupVariant/LeaveGamePopup';
+import { DiscloseMockDelayPopupModal } from './PopupVariant/DiscloseMockDelayPopup';
 
 const focusHandlerStyle = (type: PopupType, data: PopupData, index: number, playerName:string, containCards?:boolean): SxProps<Theme> => ({
     zIndex: 11 + index,
@@ -79,6 +80,8 @@ const PopupShell: React.FC<IPopupShellProps> = ({
                 return <DropdownPopupModal data={data as DropdownPopup} />;
             case 'leaveGame':
                 return <LeaveGamePopupModule uuid={data.uuid} />;
+            case 'discloseMockDelay':
+                return <DiscloseMockDelayPopupModal data={data as DiscloseMockDelayPopup} />;
             default:
                 return null;
         }

--- a/src/app/_components/_sharedcomponents/Popup/Popup.types.ts
+++ b/src/app/_components/_sharedcomponents/Popup/Popup.types.ts
@@ -63,3 +63,12 @@ export type LeaveGamePopup = {
     uuid: string;
     source: PopupSource;
 };
+
+export type DiscloseMockDelayPopup = {
+    type: 'discloseMockDelay';
+    uuid: string;
+    title: string;
+    delayMs: number;
+    source: PopupSource;
+    buttons: PopupButton[];
+};

--- a/src/app/_components/_sharedcomponents/Popup/PopupVariant/DiscloseMockDelayPopup.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/PopupVariant/DiscloseMockDelayPopup.tsx
@@ -1,0 +1,67 @@
+import { Box, IconButton, Typography } from '@mui/material';
+import { MouseEvent, useEffect, useState } from 'react';
+import { BiMinus, BiPlus } from 'react-icons/bi';
+import {
+    containerStyle,
+    headerStyle,
+    minimizeButtonStyle,
+    textStyle,
+    titleStyle,
+} from '../Popup.styles';
+import { DiscloseMockDelayPopup } from '../Popup.types';
+import RichText from '../../RichText/RichText';
+import { useGame } from '@/app/_contexts/Game.context';
+import { usePopup } from '@/app/_contexts/Popup.context';
+
+interface Props {
+    data: DiscloseMockDelayPopup;
+}
+
+export const DiscloseMockDelayPopupModal = ({ data }: Props) => {
+    const { sendGameMessage } = useGame();
+    const { closePopup } = usePopup();
+    const [isMinimized, setIsMinimized] = useState(false);
+
+    const handlePass = () => {
+        closePopup(data.uuid);
+        if (data.buttons[0]) {
+            const btn = data.buttons[0];
+            sendGameMessage([btn.command, btn.arg, btn.uuid]);
+        }
+    };
+
+    // Auto-pass after delayMs; player may click early
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            handlePass();
+        }, data.delayMs);
+        return () => clearTimeout(timer);
+    }, [data.uuid, data.delayMs]);
+
+    const handleMinimize = (e: MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
+        setIsMinimized(!isMinimized);
+    };
+
+    return (
+        <Box sx={containerStyle}>
+            <Box sx={headerStyle(isMinimized)}>
+                <RichText text={data.title} sx={titleStyle} component={Typography} />
+                <IconButton
+                    sx={minimizeButtonStyle}
+                    aria-label="minimize"
+                    onClick={handleMinimize}
+                >
+                    {isMinimized ? <BiPlus /> : <BiMinus />}
+                </IconButton>
+            </Box>
+            {!isMinimized && (
+                <RichText
+                    text="Good job, Phil Ivey — they bought your bluff!"
+                    sx={{ ...textStyle, marginTop: '1rem', fontSize: '1rem' }}
+                    component={Typography}
+                />
+            )}
+        </Box>
+    );
+};

--- a/src/app/_contexts/Game.context.tsx
+++ b/src/app/_contexts/Game.context.tsx
@@ -145,6 +145,15 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
                     source: PopupSource.PromptState
                 });
             }
+            else if (promptType === 'discloseMockDelay') {
+                return openPopup('discloseMockDelay', {
+                    uuid: promptUuid,
+                    title: promptTitle ?? menuTitle,
+                    delayMs: promptState.delayMs ?? 1000,
+                    buttons: buttons,
+                    source: PopupSource.PromptState
+                });
+            }
             else if (buttons.length > 0 && menuTitle && promptUuid && !selectCardMode) {
                 return openPopup('default', {
                     uuid: promptUuid,

--- a/src/app/_contexts/Popup.context.tsx
+++ b/src/app/_contexts/Popup.context.tsx
@@ -2,6 +2,7 @@
 import React, { createContext, useContext, useCallback, useState } from 'react';
 import {
     DefaultPopup,
+    DiscloseMockDelayPopup,
     DropdownPopup,
     PilePopup,
     SelectCardsPopup,
@@ -13,7 +14,8 @@ export type PopupData =
   | SelectCardsPopup
   | PilePopup
   | DropdownPopup
-  | LeaveGamePopup;
+  | LeaveGamePopup
+  | DiscloseMockDelayPopup;
 
 export type PopupType = PopupData['type'];
 


### PR DESCRIPTION
Adding a timer feature to the Disclose mechanic: Opponents have an unfair advantage if a player cannot Disclose because the client simply skips the popup, hinting to the opponent that the player lacks the cards for Disclose. With this PR, a popup will still appear and the "skip" button will be highlighted, draining away based on a random time generated by the [backend](https://github.com/SWU-Karabast/forceteki/pull/2306).

Currently an early version, the timer is visible on the "skip" button and the popup with some notification text appears when appropriate. A preview is below.

https://github.com/user-attachments/assets/2613b3ca-5174-4b11-bea0-4710f34d7b74