### PR TITLE
feat: add CardCore (cardcore.gg) as supported deck import source

### DIFF
--- a/src/app/DeckPage/page.tsx
+++ b/src/app/DeckPage/page.tsx
@@ -239,6 +239,8 @@ const DeckPage: React.FC = () => {
                 return styles.mySwuTag;
             case 'PROTECTTHEPOD':
                 return styles.protectThePodTag;
+            case 'CARDCORE':
+                return styles.cardCoreTag;
             default:
                 console.log(`Unknown deck source: ${deckSource}`);
                 return styles.unknownTag;
@@ -466,6 +468,15 @@ const DeckPage: React.FC = () => {
                 color: '#000000',
             },
             boxShadow: '0 0 5px #B388FF',
+        },
+        cardCoreTag: {
+            borderColor: '#FF6B35',
+            color: '#FF6B35',
+            '&:hover': {
+                backgroundColor: '#FF6B35',
+                color: '#000000',
+            },
+            boxShadow: '0 0 5px #FF6B35',
         },
         unknownTag: {
             color: 'white',

--- a/src/app/_constants/constants.ts
+++ b/src/app/_constants/constants.ts
@@ -121,6 +121,8 @@ export const SupportedDeckSources = Object.values(DeckSource)
                 return 'swuforge.com';
             case DeckSource.KyberDecks:
                 return 'kyberdecks.com';
+            case DeckSource.CardCore:
+                return 'cardcore.gg';
             default:
                 return source;
         }

--- a/src/app/_utils/checkJson.ts
+++ b/src/app/_utils/checkJson.ts
@@ -222,7 +222,8 @@ export const parseInputAsDeckData = (input: string): {
         input.includes('my-swu.com') ||
         input.includes('protectthepod.com') ||
         input.includes('swuforge.com') ||
-        input.includes('kyberdecks.com')
+        input.includes('kyberdecks.com') ||
+        input.includes('cardcore.gg')
     ) {
         return { type: 'url', data: null };
     }

--- a/src/app/_utils/fetchDeckData.ts
+++ b/src/app/_utils/fetchDeckData.ts
@@ -22,6 +22,7 @@ export enum DeckSource {
     ProtectThePod = 'ProtectThePod',
     SWUForge = 'SWUForge',
     KyberDecks = 'KyberDecks',
+    CardCore = 'CardCore',
 }
 
 export interface IDeckData {
@@ -90,6 +91,8 @@ export const determineDeckSource = (deckLink: string): DeckSource => {
         return DeckSource.SWUForge;
     } else if (deckLink.includes('kyberdecks.com')) {
         return DeckSource.KyberDecks;
+    } else if (deckLink.includes('cardcore.gg')) {
+        return DeckSource.CardCore;
     }
 
     // Default fallback

--- a/src/app/api/swudbdeck/route.ts
+++ b/src/app/api/swudbdeck/route.ts
@@ -285,6 +285,32 @@ export async function GET(req: Request) {
                 console.error('KyberDecks API error:', response.statusText);
                 throw new Error(`KyberDecks API error: ${response.statusText}`);
             }
+        } else if (deckLink.includes('cardcore.gg')) {
+            // Deck Links in the form: https://store.cardcore.gg/decks/${deckId}
+            const match = deckLink.match(/\/decks\/(\d+)\/?$/);
+            const deckId = match ? match[1] : null;
+            if (deckId != null) deckIdentifier = deckId;
+            deckSource = DeckSource.CardCore;
+
+            if (!deckId) {
+                console.error('Error: Invalid deckLink format');
+                return NextResponse.json(
+                    { error: 'Invalid deckLink format' },
+                    { status: 400 }
+                );
+            }
+
+            const apiUrl = `https://store.cardcore.gg/api/decks/${deckId}/json`;
+
+            response = await fetch(apiUrl, { method: 'GET', cache: 'no-store' });
+            if (!response.ok) {
+                if (response.status === 404) {
+                    return NextResponse.json({ error: 'Deck not found. Make sure the deck is set to Public on cardcore.gg.' }, { status: 404 });
+                }
+
+                console.error('CardCore API error:', response.statusText);
+                throw new Error(`CardCore API error: ${response.statusText}`);
+            }
         } else {
             console.error('Error: Deckbuilder not supported');
             return NextResponse.json({ error: 'Deckbuilder not supported' }, { status: 400 });


### PR DESCRIPTION
## Summary

Adds [CardCore](https://store.cardcore.gg) as a supported deck import source. CardCore is a community-driven multi-store TCG platform with a public deck builder for Star Wars Unlimited.

- Public decks on CardCore expose a Karabast-compatible JSON endpoint at `/api/decks/{id}/json` returning card IDs in standard SWU format (e.g. `SOR_001`)
- Deck URL pattern: `store.cardcore.gg/decks/{deckId}`

## Changes

| File | Change |
|------|--------|
| `fetchDeckData.ts` | Add `CardCore` to `DeckSource` enum + `determineDeckSource()` |
| `checkJson.ts` | Add `cardcore.gg` to URL detection in `parseInputAsDeckData()` |
| `constants.ts` | Add `cardcore.gg` display domain to `SupportedDeckSources` |
| `swudbdeck/route.ts` | Add CardCore API fetch handler |
| `DeckPage/page.tsx` | Add CardCore badge styling (orange `#FF6B35`) |

Follows the same pattern as KyberDecks (#660), SWUBase (#471), and other existing integrations.

## Test plan

- [ ] Paste a public CardCore deck link (e.g. `https://store.cardcore.gg/decks/155`) and verify it loads
- [ ] Verify leader, base, deck, and sideboard cards import correctly
- [ ] Verify private/non-existent deck links show appropriate error messages
- [ ] Verify CardCore badge displays with orange styling on the deck page