### PR TITLE
Added HoloScan deck source

### DIFF
--- a/src/app/_constants/constants.ts
+++ b/src/app/_constants/constants.ts
@@ -123,6 +123,8 @@ export const SupportedDeckSources = Object.values(DeckSource)
                 return 'kyberdecks.com';
             case DeckSource.CardCore:
                 return 'cardcore.gg';
+            case DeckSource.HoloScan:
+                return 'holoscan.net';
             default:
                 return source;
         }

--- a/src/app/_utils/checkJson.ts
+++ b/src/app/_utils/checkJson.ts
@@ -223,7 +223,8 @@ export const parseInputAsDeckData = (input: string): {
         input.includes('protectthepod.com') ||
         input.includes('swuforge.com') ||
         input.includes('kyberdecks.com') ||
-        input.includes('cardcore.gg')
+        input.includes('cardcore.gg') ||
+        input.includes('holoscan.net')
     ) {
         return { type: 'url', data: null };
     }

--- a/src/app/_utils/fetchDeckData.ts
+++ b/src/app/_utils/fetchDeckData.ts
@@ -23,6 +23,7 @@ export enum DeckSource {
     SWUForge = 'SWUForge',
     KyberDecks = 'KyberDecks',
     CardCore = 'CardCore',
+    HoloScan = 'HoloScan'
 }
 
 export interface IDeckData {
@@ -93,6 +94,8 @@ export const determineDeckSource = (deckLink: string): DeckSource => {
         return DeckSource.KyberDecks;
     } else if (deckLink.includes('cardcore.gg')) {
         return DeckSource.CardCore;
+    } else if (deckLink.includes('holoscan.net')) {
+        return DeckSource.HoloScan;
     }
 
     // Default fallback

--- a/src/app/api/swudbdeck/route.ts
+++ b/src/app/api/swudbdeck/route.ts
@@ -311,6 +311,33 @@ export async function GET(req: Request) {
                 console.error('CardCore API error:', response.statusText);
                 throw new Error(`CardCore API error: ${response.statusText}`);
             }
+        } else if (deckLink.includes('holoscan.net')) {
+            // Deck Links in the forms:
+            // https://holoscan.net/decks/${deckId}  (e.g. STd7VXjQoaLRS6Y6my5Q or t-409272-a1111904)
+            const match = deckLink.match(/\/decks\/([^\/]+)\/?$/);
+            const deckId = match ? match[1] : null;
+            if (deckId != null) deckIdentifier = deckId;
+            deckSource = DeckSource.HoloScan;
+
+            if (!deckId) {
+                console.error('Error: Invalid deckLink format');
+                return NextResponse.json(
+                    { error: 'Invalid deckLink format' },
+                    { status: 400 }
+                );
+            }
+
+            const apiUrl = `https://holoscan.net/api/decks/${deckId}`;
+
+            response = await fetch(apiUrl, { method: 'GET', cache: 'no-store' });
+            if (!response.ok) {
+                if (response.status === 404) {
+                    return NextResponse.json({ error: 'Deck not found. Make sure the deck exists on holoscan.net.' }, { status: 404 });
+                }
+
+                console.error('HoloScan API error:', response.statusText);
+                throw new Error(`HoloScan API error: ${response.statusText}`);
+            }
         } else {
             console.error('Error: Deckbuilder not supported');
             return NextResponse.json({ error: 'Deckbuilder not supported' }, { status: 400 });


### PR DESCRIPTION
Adds HoloScan (holoscan.net) as a supported deck source in the forceteki-client application, following the same pattern established by previous deck source additions (https://github.com/SWU-Karabast/forceteki-client/pull/635, https://github.com/SWU-Karabast/forceteki-client/pull/598).

Key Changes:

URL Format Support: Recognizes patterns like holoscannet/decks/{deckId}
API Integration: Fetches from swuforge.com/api/decks/{deckId}
Enum Addition: Added HoloScan to the DeckSource enum
URL Detection: Added holoscan.net to URL parsing in checkJson.ts, fetchDeckData.ts, and route.ts
Display Naming: Added display label holoscan.net in constants.ts
Error Handling:

Returns 400 for malformed deck URLs
Returns 404 with a user-friendly message when the deck is not found on holoscan.net