### PR TITLE
Fix Admiral Trench deploy issue

### DIFF
--- a/src/app/_components/Gameboard/_subcomponents/PlayerTray/CardActionTray.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/PlayerTray/CardActionTray.tsx
@@ -157,6 +157,11 @@ const CardActionTray: React.FC = () => {
     const styles = createStyles(isPortrait);
 
     const showTrayButtons = () => {
+        if (playerState.promptState.promptType === 'displayCards') {
+            // Buttons for the display cards prompt are rendered within the popup itself, not in the action tray
+            return false;
+        }
+
         if ( playerState.promptState.promptType === 'actionWindow' ||
              playerState.promptState.promptType === 'resource' ||
              playerState.promptState.promptType === 'distributeAmongTargets' ||

--- a/src/app/_components/_sharedcomponents/Popup/Popup.types.ts
+++ b/src/app/_components/_sharedcomponents/Popup/Popup.types.ts
@@ -11,6 +11,7 @@ export type PopupButton = {
     command: string;
     arg: string;
     selected?: boolean;
+    disabled?: boolean;
 };
 
 export type PerCardButton = {

--- a/src/app/_components/_sharedcomponents/Popup/PopupVariant/SelectCardsPopup.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/PopupVariant/SelectCardsPopup.tsx
@@ -126,6 +126,7 @@ export const SelectCardsPopupModal = ({ data }: ButtonProps) => {
                             key={`${button.arg}:${index}`}
                             sx={perCardButtonStyle}
                             variant="contained"
+                            disabled={button.disabled}
                             onClick={() => {
                                 sendGameMessage([button.command, button.arg, data.uuid]);
                             }}


### PR DESCRIPTION
Admiral Trench's deploy was bugged because the opponent could click "Done" without selecting any cards.

This was because the SelectCardPopup was not respecting the button state sent from the BE. The button state is not respected, and the player card tray no longer duplicates the button in the popup.
