### PR TITLE
Filtered lobbies (FE) — opponent-archetype filter on public lobbies

### DIFF
--- a/src/app/_components/HomePage/HomePageTypes.ts
+++ b/src/app/_components/HomePage/HomePageTypes.ts
@@ -1,5 +1,5 @@
 import { ICardData } from '@/app/_components/_sharedcomponents/Cards/CardTypes';
-import { SwuGameFormat, GamesToWinMode, CardPool } from '@/app/_constants/constants';
+import { SwuGameFormat, GamesToWinMode, CardPool, OpponentArchetype } from '@/app/_constants/constants';
 
 export interface IHexagonProps {
     backgroundColor: string;
@@ -39,6 +39,7 @@ export interface ILobby {
     cardPool: CardPool;
     gamesToWinMode: GamesToWinMode;
     host?: ILobbyHost;
+    archetypeFilter?: OpponentArchetype[] | null;
 }
 
 export interface IJoinableGameProps {

--- a/src/app/_components/HomePage/_subcomponents/JoinableGame/JoinableGame.tsx
+++ b/src/app/_components/HomePage/_subcomponents/JoinableGame/JoinableGame.tsx
@@ -8,6 +8,9 @@ import { CardStyle, ISetCode } from '@/app/_components/_sharedcomponents/Cards/C
 import { ILobbyCardData } from '../../HomePageTypes';
 import { getUserPayload } from '@/app/_utils/ServerAndLocalStorageUtils';
 import { FormatLabels, FormatTagLabels, SwuGameFormat, GamesToWinMode, CardPool, CardPoolLabels } from '@/app/_constants/constants';
+import { useArchetypeLookup } from '@/app/_utils/archetypeLookup';
+import ArchetypeFilterDetailModal from '@/app/_components/_sharedcomponents/OpponentPreferences/ArchetypeFilterDetailModal';
+import JoinFilteredLobbyModal from '@/app/_components/_sharedcomponents/JoinFilteredLobbyModal/JoinFilteredLobbyModal';
 import PremierIcon from '/public/premier.svg';
 import EternalIcon from '/public/eternal.svg';
 import OpenIcon from '/public/open.svg';
@@ -18,10 +21,24 @@ import Bo3Icon from '/public/bo3.svg';
 const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
     const router = useRouter();
     const { user } = useUser();
+    const lookup = useArchetypeLookup();
+    const activeArchetypes = (lobby.archetypeFilter ?? []).filter((a) => a.enabled !== false);
+    const isFiltered = activeArchetypes.length > 0;
+
+    const [showJoinModal, setShowJoinModal] = React.useState<boolean>(false);
+    const [showFilterDetail, setShowFilterDetail] = React.useState<boolean>(false);
     const [anchorElement, setAnchorElement] = React.useState<HTMLElement | null>(null);
     const [previewImage, setPreviewImage] = React.useState<string | null>(null);
     const hoverTimeout = React.useRef<number | undefined>(undefined);
     const open = Boolean(anchorElement);
+
+    const handleJoinClick = () => {
+        if (isFiltered) {
+            setShowJoinModal(true);
+        } else {
+            void joinLobby(lobby.id);
+        }
+    };
 
     const handlePreviewOpen = (event: React.MouseEvent<HTMLElement>) => {
         const target = event.currentTarget;
@@ -100,7 +117,9 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
         },
         cardsContainer: {
             display: 'flex',
+            flexDirection: 'column',
             alignItems: 'center',
+            gap: '10px',
             paddingLeft: '10px',
         },
         parentBoxStyling: {
@@ -192,8 +211,23 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
                     color: '#ff66b2',
                     boxShadow: '0 0 5px #ff66b2',
                 }
-            }
-        }
+            },
+        },
+        viewAllButton: {
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '4px 10px',
+            borderRadius: '15px',
+            fontSize: '0.7rem',
+            fontWeight: 500,
+            color: '#bfe1ff',
+            border: '1px solid #78c8ff',
+            background: 'transparent',
+            cursor: 'pointer',
+            whiteSpace: 'nowrap' as const,
+            '&:hover': { backgroundColor: 'rgba(120, 200, 255, 0.12)' },
+        },
     };
 
     const getGameFormatTagStyle = (format: SwuGameFormat) => {
@@ -302,9 +336,9 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
                 <Box sx={styles.lobbyInfo}>
                     {lobby.host && (
                         <Box sx={styles.cardsContainer}>
-                            <Box sx={{ position: 'relative' }}>
+                            <Box sx={{ position: 'relative', paddingBottom: '24px' }}>
                                 <Box>
-                                    <Box 
+                                    <Box
                                         sx={{
                                             ...styles.cardPreview,
                                             backgroundImage: `url(${s3CardImageURL(createCardObject(lobby.host.base), CardStyle.Plain)})`
@@ -317,7 +351,7 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
                                     </Box>
                                 </Box>
                                 <Box sx={styles.parentBoxStyling}>
-                                    <Box 
+                                    <Box
                                         sx={{
                                             ...styles.cardPreview,
                                             backgroundImage: `url(${s3CardImageURL(createCardObject(lobby.host.leader), CardStyle.PlainLeader)})`
@@ -330,6 +364,16 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
                                     </Box>
                                 </Box>
                             </Box>
+                            {isFiltered && (
+                                <Box
+                                    component="button"
+                                    type="button"
+                                    sx={styles.viewAllButton}
+                                    onClick={() => setShowFilterDetail(true)}
+                                >
+                                    Allowed Decks ({activeArchetypes.length})
+                                </Box>
+                            )}
                         </Box>
                     )}
                     <Box>
@@ -369,7 +413,7 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
                         </Box>
                     </Box>
                 </Box>
-                <Button onClick={() => joinLobby(lobby.id)}>Join</Button>
+                <Button onClick={handleJoinClick}>Join</Button>
             </Box>
             <Popover
                 id="mouse-over-popover"
@@ -383,6 +427,20 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
             >
                 <Box sx={{ ...styles.cardPopover, backgroundImage: previewImage }} />
             </Popover>
+            {showJoinModal && (
+                <JoinFilteredLobbyModal
+                    lobby={lobby}
+                    onClose={() => setShowJoinModal(false)}
+                />
+            )}
+            {showFilterDetail && (
+                <ArchetypeFilterDetailModal
+                    onClose={() => setShowFilterDetail(false)}
+                    lobbyName={lobby.name}
+                    archetypes={activeArchetypes}
+                    lookup={lookup}
+                />
+            )}
         </>
     );
 };

--- a/src/app/_components/_sharedcomponents/CreateGameForm/CreateGameForm.tsx
+++ b/src/app/_components/_sharedcomponents/CreateGameForm/CreateGameForm.tsx
@@ -36,6 +36,11 @@ import FormatSelectionForm from '../FormatSelectionForm/FormatSelectionForm';
 import NewFormatAvailableAnnouncement from '../../NewFormatAvailableAnnouncement/NewFormatAvailableAnnouncement';
 import { NewGameFormatAvailable } from '@/app/_constants/constants';
 import { IDeckPreferences } from '@/app/_hooks/useDeckManagement';
+import OpponentPreferencesModal from '../OpponentPreferences/OpponentPreferencesModal';
+import { loadMatchPreferences } from '@/app/_utils/matchPreferences';
+import PreferenceButton from '../Preferences/_subComponents/PreferenceButton';
+
+type LobbyType = 'public' | 'public-filtered' | 'private';
 
 interface IDeckPreferencesHandlers {
     setShowSavedDecks: (value: boolean) => void;
@@ -115,7 +120,16 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
     }, [deckPreferences.matchConfig.format, deckPreferences.matchConfig.cardPool, deckPreferences.matchConfig.gamesToWinMode, formats, formatConfigs]);
 
     // Common State
-    const [privateGame, setPrivateGame] = useState<boolean>(false);
+    const [lobbyType, setLobbyType] = useState<LobbyType>('public');
+    const [showPrefsModal, setShowPrefsModal] = useState<boolean>(false);
+    const [activeFilterCount, setActiveFilterCount] = useState<number>(() => {
+        const prefs = loadMatchPreferences();
+        return prefs.allowedArchetypes.filter((a) => a.enabled !== false).length;
+    });
+    const refreshFilterCount = () => {
+        const prefs = loadMatchPreferences();
+        setActiveFilterCount(prefs.allowedArchetypes.filter((a) => a.enabled !== false).length);
+    };
 
     // Additional State for Non-Creategame Path
     const [lobbyName, setLobbyName] = useState<string>('');
@@ -222,14 +236,18 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
                     saveDeckToLocalStorage(deckData, deckLink);
                 }
             }
+            const archetypeFilter = lobbyType === 'public-filtered'
+                ? loadMatchPreferences().allowedArchetypes.filter((a) => a.enabled !== false)
+                : null;
             const payload = {
                 user: getUserPayload(user),
                 deck: deckData,
-                isPrivate: privateGame,
+                isPrivate: lobbyType === 'private',
                 format: lobbyConfig.format,
                 lobbyName: lobbyName,
                 cardPool: lobbyConfig.cardPool,
                 gamesToWinMode: lobbyConfig.gamesToWinMode,
+                ...(archetypeFilter && archetypeFilter.length > 0 ? { archetypeFilter } : {}),
             };
             const response = await fetch(`${process.env.NEXT_PUBLIC_ROOT_URL}/api/create-lobby`,
                 {
@@ -348,7 +366,17 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
             alignItems: 'center',
             justifyContent: 'center',
             padding: '1rem',
-        }
+        },
+        filteredHelperRow: {
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.75rem',
+            flexWrap: 'wrap' as const,
+        },
+        filteredHelperText: {
+            color: '#cccccc',
+            fontSize: '0.9em',
+        },
     }
 
     // Render SWU Stats decks dropdown
@@ -640,14 +668,14 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
                 <FormControl component="fieldset" sx={styles.formControlStyle}>
                     <RadioGroup
                         row
-                        value={privateGame ? 'Private' : 'Public'}
+                        value={lobbyType}
                         onChange={(
                             e: ChangeEvent<HTMLInputElement>,
                             value: string
-                        ) => setPrivateGame(value === 'Private')}
+                        ) => setLobbyType(value as LobbyType)}
                     >
                         <FormControlLabel
-                            value="Public"
+                            value="public"
                             control={<Radio sx={styles.checkboxStyle} />}
                             label={
                                 <Typography sx={styles.checkboxAndRadioGroupTextStyle}>
@@ -656,7 +684,16 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
                             }
                         />
                         <FormControlLabel
-                            value="Private"
+                            value="public-filtered"
+                            control={<Radio sx={styles.checkboxStyle} />}
+                            label={
+                                <Typography sx={styles.checkboxAndRadioGroupTextStyle}>
+                                    Public (Filtered)
+                                </Typography>
+                            }
+                        />
+                        <FormControlLabel
+                            value="private"
                             control={<Radio sx={styles.checkboxStyle} />}
                             label={
                                 <Typography sx={styles.checkboxAndRadioGroupTextStyle}>
@@ -667,10 +704,27 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
                     </RadioGroup>
                 </FormControl>
 
+                {lobbyType === 'public-filtered' && (
+                    <FormControl component="fieldset" sx={styles.formControlStyle}>
+                        <Box sx={styles.filteredHelperRow}>
+                            <PreferenceButton
+                                variant="standard"
+                                text="Manage Opponent Preferences"
+                                buttonFnc={() => setShowPrefsModal(true)}
+                            />
+                            <Typography sx={styles.filteredHelperText}>
+                                {activeFilterCount === 0
+                                    ? 'No allowed archetypes set — add at least one to create the lobby.'
+                                    : `${activeFilterCount} archetype${activeFilterCount === 1 ? '' : 's'} active.`}
+                            </Typography>
+                        </Box>
+                    </FormControl>
+                )}
+
                 {/* Beta Announcement */}
                 { NewGameFormatAvailable && <NewFormatAvailableAnnouncement format={NewGameFormatAvailable} />}
 
-                {!privateGame && (
+                {lobbyType !== 'private' && (
                     <>
                         <FormControl fullWidth sx={styles.formControlStyle}>
                             <Typography variant="body1" sx={styles.labelTextStyle}>
@@ -690,10 +744,22 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
                 )}
 
                 {/* Submit Button */}
-                <Button type="submit" variant="contained" sx={styles.submitButtonStyle}>
+                <Button
+                    type="submit"
+                    variant="contained"
+                    sx={styles.submitButtonStyle}
+                    disabled={lobbyType === 'public-filtered' && activeFilterCount === 0}
+                >
                     Create Game
                 </Button>
             </form>
+            <OpponentPreferencesModal
+                open={showPrefsModal}
+                onClose={() => {
+                    setShowPrefsModal(false);
+                    refreshFilterCount();
+                }}
+            />
         </Box>
     );
 };

--- a/src/app/_components/_sharedcomponents/JoinFilteredLobbyModal/JoinFilteredLobbyModal.tsx
+++ b/src/app/_components/_sharedcomponents/JoinFilteredLobbyModal/JoinFilteredLobbyModal.tsx
@@ -1,0 +1,278 @@
+'use client';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Box, FormControl, FormControlLabel, MenuItem, Radio, RadioGroup, Typography } from '@mui/material';
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { useUser } from '@/app/_contexts/User.context';
+import { getUserPayload, loadDecks, loadSavedDecks } from '@/app/_utils/ServerAndLocalStorageUtils';
+import { fetchDeckData } from '@/app/_utils/fetchDeckData';
+import { parseInputAsDeckData } from '@/app/_utils/checkJson';
+import OverlayDialog from '@/app/_components/_sharedcomponents/OverlayDialog/OverlayDialog';
+import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
+import StyledTextField from '@/app/_components/_sharedcomponents/_styledcomponents/StyledTextField';
+import { StoredDeck } from '@/app/_components/_sharedcomponents/Cards/CardTypes';
+import { ILobby } from '@/app/_components/HomePage/HomePageTypes';
+import { Aspect, OpponentArchetype } from '@/app/_constants/constants';
+import { useArchetypeLookup } from '@/app/_utils/archetypeLookup';
+import ReadOnlyArchetypeList from '@/app/_components/_sharedcomponents/OpponentPreferences/ReadOnlyArchetypeList';
+
+interface IJoinFilteredLobbyModalProps {
+    lobby: ILobby;
+    onClose: () => void;
+}
+
+type DeckSourceMode = 'saved' | 'new';
+
+const JoinFilteredLobbyModal: React.FC<IJoinFilteredLobbyModalProps> = ({ lobby, onClose }) => {
+    const router = useRouter();
+    const { user } = useUser();
+    const { data: session } = useSession();
+    const lookup = useArchetypeLookup();
+
+    const [savedDecks, setSavedDecks] = useState<StoredDeck[]>([]);
+    const [deckSourceMode, setDeckSourceMode] = useState<DeckSourceMode>('saved');
+    const [selectedSavedDeckId, setSelectedSavedDeckId] = useState<string>('');
+    const [deckInput, setDeckInput] = useState<string>('');
+    const [submitting, setSubmitting] = useState<boolean>(false);
+    const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            try {
+                const sessionUser = session?.user as { userId?: string } | undefined;
+                const decks = sessionUser?.userId && user
+                    ? await loadDecks(user)
+                    : loadSavedDecks();
+                if (cancelled) return;
+                const sorted = [...decks].sort((a, b) => {
+                    if (a.favourite && !b.favourite) return -1;
+                    if (!a.favourite && b.favourite) return 1;
+                    return 0;
+                });
+                setSavedDecks(sorted);
+                if (sorted.length > 0) {
+                    setSelectedSavedDeckId((prev) => prev || sorted[0].deckID);
+                }
+            } catch (err) {
+                if (cancelled) return;
+                console.error('JoinFilteredLobbyModal: error loading decks', err);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [session?.user, user]);
+
+    const activeArchetypes = useMemo(
+        () => (lobby.archetypeFilter ?? []).filter((a) => a.enabled !== false),
+        [lobby.archetypeFilter],
+    );
+
+    const baseIdToAspects = useMemo(() => {
+        const map = new Map<string, Aspect[]>();
+        if (lookup) {
+            for (const bt of lookup.baseTypesByJoinedIds.values()) {
+                for (const id of bt.baseIds) {
+                    map.set(id, bt.aspects ?? []);
+                }
+            }
+        }
+        return map;
+    }, [lookup]);
+
+    const archetypeMatches = (arch: OpponentArchetype, leaderId: string, baseId: string): boolean => {
+        if (arch.leaderId !== leaderId) return false;
+        const c = arch.baseConstraint;
+        if (!c) return true;
+        if (c.kind === 'baseType') return c.baseIds.includes(baseId);
+        if (c.kind === 'aspect') {
+            return (baseIdToAspects.get(baseId) ?? []).includes(c.aspect);
+        }
+        return false;
+    };
+
+    const deckMatchesFilter = (deck: StoredDeck): boolean => {
+        if (!lookup) return true; // optimistic until lookup loads
+        return activeArchetypes.some((a) => archetypeMatches(a, deck.leader.id, deck.base.id));
+    };
+
+    const handleSubmit = async () => {
+        let source = '';
+        if (deckSourceMode === 'saved') {
+            const selected = savedDecks.find((d) => d.deckID === selectedSavedDeckId);
+            if (!selected?.deckLink) {
+                setErrorMsg('Please select a saved deck.');
+                return;
+            }
+            source = selected.deckLink;
+        } else {
+            source = deckInput.trim();
+            if (!source) {
+                setErrorMsg('Please paste a deck link or JSON.');
+                return;
+            }
+        }
+        setSubmitting(true);
+        setErrorMsg(null);
+        try {
+            const parsed = parseInputAsDeckData(source);
+            let deckData;
+            if (parsed.type === 'url') {
+                deckData = await fetchDeckData(source, false);
+            } else if (parsed.type === 'json') {
+                deckData = parsed.data;
+            } else {
+                setErrorMsg('Could not parse deck — please paste a valid SWU deck link or JSON.');
+                setSubmitting(false);
+                return;
+            }
+            const payload = {
+                lobbyId: lobby.id,
+                user: getUserPayload(user),
+                deck: deckData,
+            };
+            const response = await fetch(`${process.env.NEXT_PUBLIC_ROOT_URL}/api/join-lobby`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+                credentials: 'include',
+            });
+            const result = await response.json();
+            if (!response.ok) {
+                setErrorMsg(result.message || 'Could not join lobby.');
+                setSubmitting(false);
+                return;
+            }
+            router.push('/lobby');
+        } catch (err) {
+            setErrorMsg(err instanceof Error ? err.message : 'Error joining lobby.');
+            setSubmitting(false);
+        }
+    };
+
+    const decksWithMatchStatus = useMemo(() => {
+        const enriched = savedDecks.map((deck) => ({ deck, matches: deckMatchesFilter(deck) }));
+        enriched.sort((a, b) => {
+            if (a.matches !== b.matches) return a.matches ? -1 : 1;
+            if (a.deck.favourite !== b.deck.favourite) return a.deck.favourite ? -1 : 1;
+            return a.deck.name.localeCompare(b.deck.name);
+        });
+        return enriched;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [savedDecks, lookup, activeArchetypes]);
+
+    // Reset selection to first matching deck when lookup becomes available, in case
+    // the initial auto-selection landed on a non-matching deck before the filter was known.
+    useEffect(() => {
+        if (!lookup || decksWithMatchStatus.length === 0) return;
+        const current = decksWithMatchStatus.find((d) => d.deck.deckID === selectedSavedDeckId);
+        if (current?.matches) return;
+        const firstMatching = decksWithMatchStatus.find((d) => d.matches);
+        setSelectedSavedDeckId(firstMatching ? firstMatching.deck.deckID : '');
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [lookup, decksWithMatchStatus]);
+
+    const submitDisabled = submitting
+        || (deckSourceMode === 'saved' && !selectedSavedDeckId)
+        || (deckSourceMode === 'new' && deckInput.trim().length === 0);
+
+    const styles = {
+        heading: { fontWeight: 600, color: '#fff', paddingRight: '2rem' },
+        lobbyName: { color: '#cccccc', fontSize: '0.95rem' },
+        sectionHeading: {
+            color: '#fff',
+            fontWeight: 600,
+            fontSize: '0.95rem',
+            marginTop: '0.25rem',
+        },
+        radioGroupText: { color: '#fff', fontSize: '0.9rem' },
+        error: { color: '#ff8080', fontSize: '0.85rem' },
+        actions: {
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: '0.75rem',
+            marginTop: '0.5rem',
+        },
+    };
+
+    return (
+        <OverlayDialog onClose={onClose}>
+            <Typography variant="h5" sx={styles.heading}>Join Filtered Lobby</Typography>
+            <Typography sx={styles.lobbyName}>{lobby.name}</Typography>
+
+            <Typography sx={styles.sectionHeading}>Allowed archetypes ({activeArchetypes.length})</Typography>
+            <ReadOnlyArchetypeList archetypes={activeArchetypes} lookup={lookup} maxHeight="40vh" />
+
+            <Typography sx={styles.sectionHeading}>Your deck</Typography>
+            <FormControl component="fieldset">
+                <RadioGroup
+                    row
+                    value={deckSourceMode}
+                    onChange={(_, v) => setDeckSourceMode(v as DeckSourceMode)}
+                >
+                    <FormControlLabel
+                        value="saved"
+                        control={<Radio sx={{ color: '#fff', '&.Mui-checked': { color: '#fff' }, '&.Mui-disabled': { color: 'rgba(255, 255, 255, 0.35)' } }} />}
+                        label={<Typography sx={styles.radioGroupText}>Saved deck</Typography>}
+                    />
+                    <FormControlLabel
+                        value="new"
+                        control={<Radio sx={{ color: '#fff', '&.Mui-checked': { color: '#fff' }, '&.Mui-disabled': { color: 'rgba(255, 255, 255, 0.35)' } }} />}
+                        label={<Typography sx={styles.radioGroupText}>New deck link / JSON</Typography>}
+                    />
+                </RadioGroup>
+            </FormControl>
+
+            {deckSourceMode === 'saved' && (
+                <StyledTextField
+                    select
+                    value={selectedSavedDeckId}
+                    onChange={(e) => setSelectedSavedDeckId(e.target.value as string)}
+                    disabled={submitting}
+                    placeholder="Favorite Decks"
+                    SelectProps={{ displayEmpty: true }}
+                >
+                    {decksWithMatchStatus.length === 0 ? (
+                        <MenuItem value="" disabled>No saved decks found</MenuItem>
+                    ) : (
+                        decksWithMatchStatus.map(({ deck, matches }) => (
+                            <MenuItem key={deck.deckID} value={deck.deckID} disabled={!matches}>
+                                {deck.favourite ? '★ ' : ''}{deck.name}
+                                {!matches && (
+                                    <span style={{ marginLeft: '0.5rem', color: '#999', fontSize: '0.85em' }}>
+                                        — doesn{'’'}t match filter
+                                    </span>
+                                )}
+                            </MenuItem>
+                        ))
+                    )}
+                </StyledTextField>
+            )}
+
+            {deckSourceMode === 'new' && (
+                <StyledTextField
+                    value={deckInput}
+                    onChange={(e) => setDeckInput(e.target.value)}
+                    placeholder="https://swudb.com/deck/..."
+                    multiline
+                    minRows={2}
+                    maxRows={4}
+                    disabled={submitting}
+                />
+            )}
+
+            {errorMsg && <Typography sx={styles.error}>{errorMsg}</Typography>}
+
+            <Box sx={styles.actions}>
+                <PreferenceButton text="Cancel" buttonFnc={onClose} variant="standard" />
+                <PreferenceButton
+                    text={submitting ? 'Joining…' : 'Join'}
+                    buttonFnc={handleSubmit}
+                    variant="standard"
+                    disabled={submitDisabled}
+                />
+            </Box>
+        </OverlayDialog>
+    );
+};
+
+export default JoinFilteredLobbyModal;

--- a/src/app/_components/_sharedcomponents/OpponentPreferences/ArchetypeFilterDetailModal.tsx
+++ b/src/app/_components/_sharedcomponents/OpponentPreferences/ArchetypeFilterDetailModal.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import OverlayDialog from '@/app/_components/_sharedcomponents/OverlayDialog/OverlayDialog';
+import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
+import ReadOnlyArchetypeList from './ReadOnlyArchetypeList';
+import { OpponentArchetype } from '@/app/_constants/constants';
+import { IArchetypeLookup } from '@/app/_utils/archetypeLookup';
+
+interface IArchetypeFilterDetailModalProps {
+    onClose: () => void;
+    lobbyName: string;
+    archetypes: OpponentArchetype[];
+    lookup: IArchetypeLookup | null;
+}
+
+const ArchetypeFilterDetailModal: React.FC<IArchetypeFilterDetailModalProps> = ({
+    onClose, lobbyName, archetypes, lookup,
+}) => {
+    const styles = {
+        heading: { fontWeight: 600, color: '#fff', paddingRight: '2rem' },
+        subheading: { color: '#cccccc', fontSize: '0.95rem' },
+        footer: { display: 'flex', justifyContent: 'flex-end', marginTop: '0.5rem' },
+    };
+
+    return (
+        <OverlayDialog onClose={onClose}>
+            <Typography variant="h5" sx={styles.heading}>Allowed Archetypes</Typography>
+            <Typography sx={styles.subheading}>{lobbyName}</Typography>
+
+            <ReadOnlyArchetypeList archetypes={archetypes} lookup={lookup} />
+
+            <Box sx={styles.footer}>
+                <PreferenceButton text="Close" buttonFnc={onClose} variant="standard" />
+            </Box>
+        </OverlayDialog>
+    );
+};
+
+export default ArchetypeFilterDetailModal;

--- a/src/app/_components/_sharedcomponents/OpponentPreferences/ArchetypeRow.tsx
+++ b/src/app/_components/_sharedcomponents/OpponentPreferences/ArchetypeRow.tsx
@@ -1,0 +1,253 @@
+import React from 'react';
+import { Box, Checkbox, Typography } from '@mui/material';
+import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
+import { CardStyle } from '@/app/_components/_sharedcomponents/Cards/CardTypes';
+import { Aspect, IBaseTypeOption, OpponentArchetype } from '@/app/_constants/constants';
+import BaseTilePreview from './BaseTilePreview';
+import {
+    LeaderOption,
+    baseTileKindFor,
+    cardImageUrl,
+    formatBaseTitle,
+} from './utils';
+
+interface IArchetypeRowProps {
+    archetype: OpponentArchetype;
+    isSelected: boolean;
+    leader: LeaderOption | null;
+    baseType: IBaseTypeOption | null;
+    baseAspects: Aspect[];
+    onToggleSelection: () => void;
+    onToggleEnabled: (enabled: boolean) => void;
+    onEdit: () => void;
+    isReadOnly?: boolean;
+}
+
+const ArchetypeRow: React.FC<IArchetypeRowProps> = ({
+    archetype,
+    isSelected,
+    leader,
+    baseType,
+    baseAspects,
+    onToggleSelection,
+    onToggleEnabled,
+    onEdit,
+    isReadOnly = false,
+}) => {
+    const isEnabled = archetype.enabled !== false;
+    const tileKind = baseTileKindFor(archetype.baseConstraint, baseType);
+    const baseTitle = formatBaseTitle(archetype.baseConstraint, baseType);
+    const leaderImageUrl = leader ? cardImageUrl(leader.id, CardStyle.PlainLeader) : null;
+    const uniqueBaseImageUrl = baseType && baseType.baseIds.length === 1
+        ? cardImageUrl(baseType.id)
+        : null;
+    const stop = (e: React.MouseEvent) => e.stopPropagation();
+
+    return (
+        <Box
+            sx={{
+                ...styles.row(isSelected && !isReadOnly),
+                ...(isEnabled ? null : styles.rowDisabled),
+                ...(isReadOnly ? styles.rowReadOnly : null),
+            }}
+            onClick={isReadOnly ? undefined : onToggleSelection}
+        >
+            {!isReadOnly && (
+                <Box sx={styles.toggle} onClick={stop}>
+                    <Checkbox
+                        checked={isEnabled}
+                        onChange={(e) => onToggleEnabled(e.target.checked)}
+                        sx={styles.checkbox}
+                        inputProps={{ 'aria-label': isEnabled ? 'Disable archetype' : 'Enable archetype' }}
+                    />
+                </Box>
+            )}
+            <Box sx={{ ...styles.content, ...(isReadOnly ? styles.contentReadOnly : null) }}>
+                <Box sx={{ ...styles.section, ...(isReadOnly ? styles.sectionReadOnly : null) }}>
+                    {leaderImageUrl ? (
+                        <Box sx={{ ...styles.thumb, ...(isReadOnly ? styles.thumbReadOnly : null), backgroundImage: `url(${leaderImageUrl})` }} />
+                    ) : (
+                        <Box sx={{ ...styles.thumb, ...(isReadOnly ? styles.thumbReadOnly : null), ...styles.thumbPlaceholder }} />
+                    )}
+                    <Box sx={styles.textStack}>
+                        <Typography sx={{ ...styles.title, ...(isReadOnly ? styles.titleReadOnly : null) }}>
+                            {leader ? leader.name : 'Unknown leader'}
+                        </Typography>
+                        {leader?.subtitle && (
+                            <Typography sx={styles.subtitle}>{leader.subtitle}</Typography>
+                        )}
+                    </Box>
+                </Box>
+                <Box sx={{ ...styles.section, ...(isReadOnly ? styles.sectionReadOnly : null) }}>
+                    {uniqueBaseImageUrl ? (
+                        <Box sx={{ ...styles.baseTile, ...(isReadOnly ? styles.thumbReadOnly : null), backgroundImage: `url(${uniqueBaseImageUrl})`, backgroundSize: 'contain', backgroundRepeat: 'no-repeat', backgroundPosition: 'center' }} />
+                    ) : (
+                        <Box sx={{ ...styles.baseTile, ...(isReadOnly ? styles.thumbReadOnly : null) }}>
+                            <BaseTilePreview kind={tileKind} aspects={baseAspects} />
+                        </Box>
+                    )}
+                    <Box sx={styles.textStack}>
+                        <Typography sx={{ ...styles.title, ...(isReadOnly ? styles.titleReadOnly : null) }}>{baseTitle}</Typography>
+                    </Box>
+                </Box>
+            </Box>
+            {!isReadOnly && (
+                <Box sx={styles.editSlot} onClick={stop}>
+                    <PreferenceButton variant="standard" text="Edit" buttonFnc={onEdit} />
+                </Box>
+            )}
+            {!isReadOnly && (
+                <Box
+                    sx={{ ...styles.selectionCheckmark, visibility: isSelected ? 'visible' : 'hidden' }}
+                    aria-hidden={!isSelected}
+                >
+                    <Typography sx={styles.checkmarkSymbol}>✓</Typography>
+                </Box>
+            )}
+        </Box>
+    );
+};
+
+const styles = {
+    row: (isSelected: boolean) => ({
+        background: isSelected ? '#2F7DB680' : '#20344280',
+        borderRadius: '5px',
+        border: '2px solid transparent',
+        padding: '8px 12px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '12px',
+        cursor: 'pointer',
+        position: 'relative' as const,
+        '&:hover': { backgroundColor: '#2F7DB680' },
+    }),
+    rowDisabled: { opacity: 0.55 },
+    rowReadOnly: {
+        cursor: 'default',
+        padding: '4px 8px',
+        gap: '8px',
+        containerType: 'inline-size' as const,
+        '&:hover': { backgroundColor: '#20344280' },
+    },
+    // In read-only mode, the row's content is a flex container that switches
+    // from row to column when the row's own width drops below 22rem. This is
+    // a CSS container query — it reacts to the row's container width (set via
+    // containerType above), not the viewport — so each row independently
+    // decides whether leader/base sit inline or stack.
+    contentReadOnly: {
+        flexWrap: 'nowrap' as const,
+        flexDirection: 'row' as const,
+        gap: '6px 10px',
+        '@container (max-width: 22rem)': {
+            flexDirection: 'column' as const,
+            alignItems: 'flex-start' as const,
+        },
+    },
+    sectionReadOnly: {
+        flex: '1 1 0',
+        minWidth: 0,
+        '@container (max-width: 22rem)': {
+            flex: 'none',
+            width: '100%',
+        },
+    },
+    thumbReadOnly: { width: '3rem', height: '2.15rem' },
+    titleReadOnly: {
+        fontSize: '0.95em',
+        whiteSpace: 'normal' as const,
+        overflow: 'visible',
+        textOverflow: 'clip' as const,
+    },
+    toggle: {
+        flexShrink: 0,
+        display: 'flex',
+        alignItems: 'center',
+    },
+    checkbox: {
+        flexShrink: 0,
+        color: '#fff',
+        '&.Mui-checked': { color: '#fff' },
+    },
+    content: {
+        display: 'flex',
+        flexWrap: 'wrap' as const,
+        alignItems: 'center',
+        gap: '8px 16px',
+        flex: '1 1 auto',
+        minWidth: 0,
+    },
+    section: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '10px',
+        flex: '1 1 16rem',
+        minWidth: 0,
+    },
+    thumb: {
+        width: '4rem',
+        height: '2.85rem',
+        backgroundColor: 'rgba(255, 255, 255, 0.04)',
+        backgroundSize: 'contain',
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'center',
+        borderRadius: '4px',
+        flexShrink: 0,
+    },
+    thumbPlaceholder: { border: '1px dashed rgba(255, 255, 255, 0.18)' },
+    baseTile: {
+        width: '4rem',
+        height: '2.85rem',
+        backgroundColor: 'rgba(255, 255, 255, 0.04)',
+        borderRadius: '4px',
+        flexShrink: 0,
+        fontSize: '1rem',
+    },
+    textStack: {
+        display: 'flex',
+        flexDirection: 'column' as const,
+        minWidth: 0,
+        flex: '1 1 auto',
+        overflow: 'hidden',
+    },
+    title: {
+        color: '#fff',
+        fontSize: '1.1em',
+        fontWeight: 600,
+        margin: 0,
+        lineHeight: 1.25,
+        whiteSpace: 'nowrap' as const,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+    },
+    subtitle: {
+        color: '#bbbbbb',
+        fontSize: '0.85em',
+        margin: 0,
+        lineHeight: 1.25,
+        whiteSpace: 'nowrap' as const,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+    },
+    editSlot: {
+        display: 'flex',
+        flexShrink: 0,
+    },
+    selectionCheckmark: {
+        width: '24px',
+        height: '24px',
+        borderRadius: '50%',
+        backgroundColor: '#66E5FF',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        flexShrink: 0,
+    },
+    checkmarkSymbol: {
+        color: '#1E2D32',
+        fontWeight: 'bold',
+        fontSize: '13px',
+        lineHeight: 1,
+    },
+};
+
+export default ArchetypeRow;

--- a/src/app/_components/_sharedcomponents/OpponentPreferences/BaseTilePreview.tsx
+++ b/src/app/_components/_sharedcomponents/OpponentPreferences/BaseTilePreview.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import { Aspect, BaseTypeKind } from '@/app/_constants/constants';
+import { BASE_ASPECTS, aspectHasIcon, aspectIconUrl } from './utils';
+
+// Unique base types render as a thumbnail in the parent (not this component),
+// plus the FE-only 'aspect' and 'any' display modes for archetypes that don't
+// resolve to a specific base type.
+export type BaseTileKind = Exclude<BaseTypeKind, 'unique'> | 'aspect' | 'any';
+
+interface IBaseTilePreviewProps {
+    kind: BaseTileKind;
+    aspects: Aspect[];
+}
+
+// Inner icon layout for a base-type preview. Sizes are in `em` units so the
+// parent's `font-size` controls the scale — used at small size in the list
+// row and at larger size in the edit dialog.
+const BaseTilePreview: React.FC<IBaseTilePreviewProps> = ({ kind, aspects }) => {
+    const renderableAspects = aspects.filter(aspectHasIcon);
+
+    if (kind === 'any') {
+        return (
+            <Box sx={styles.anyWrap} aria-hidden>
+                <Box sx={styles.anyCluster}>
+                    {BASE_ASPECTS.map((aspect) => (
+                        <Box
+                            key={aspect}
+                            component="img"
+                            src={aspectIconUrl(aspect)}
+                            alt=""
+                            sx={styles.anyIcon}
+                        />
+                    ))}
+                </Box>
+            </Box>
+        );
+    }
+
+    if (kind === 'force') {
+        return (
+            <Box sx={styles.forceTile}>
+                {renderableAspects.map((aspect) => (
+                    <Box
+                        key={aspect}
+                        component="img"
+                        src={aspectIconUrl(aspect)}
+                        alt={aspect}
+                        sx={styles.mainAspectIcon}
+                    />
+                ))}
+                <Box
+                    component="img"
+                    src="/ForceTokenHeroism.png"
+                    alt=""
+                    sx={styles.forceBadge}
+                />
+            </Box>
+        );
+    }
+
+    if (kind === 'splash') {
+        const others = BASE_ASPECTS.filter((a) => !renderableAspects.includes(a));
+        return (
+            <Box sx={styles.splashTile}>
+                <Box sx={styles.splashRow}>
+                    {renderableAspects.map((aspect) => (
+                        <Box
+                            key={aspect}
+                            component="img"
+                            src={aspectIconUrl(aspect)}
+                            alt={aspect}
+                            sx={styles.mainAspectIcon}
+                        />
+                    ))}
+                </Box>
+                <Box sx={styles.splashRow}>
+                    {others.map((aspect) => (
+                        <Box
+                            key={aspect}
+                            component="img"
+                            src={aspectIconUrl(aspect)}
+                            alt=""
+                            sx={styles.splashOtherIcon}
+                        />
+                    ))}
+                </Box>
+            </Box>
+        );
+    }
+
+    return (
+        <Box sx={styles.aspectRow}>
+            {renderableAspects.map((aspect) => (
+                <Box
+                    key={aspect}
+                    component="img"
+                    src={aspectIconUrl(aspect)}
+                    alt={aspect}
+                    sx={styles.mainAspectIcon}
+                />
+            ))}
+        </Box>
+    );
+};
+
+const styles = {
+    aspectRow: {
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '0.1em',
+    },
+    mainAspectIcon: {
+        width: '1.5em',
+        height: '1.5em',
+        objectFit: 'contain' as const,
+    },
+    forceTile: {
+        width: '100%',
+        height: '100%',
+        position: 'relative' as const,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '0.1em',
+    },
+    forceBadge: {
+        position: 'absolute' as const,
+        width: '1.1em',
+        height: '1.1em',
+        right: '0.65em',
+        bottom: '0.2em',
+        objectFit: 'contain' as const,
+    },
+    splashTile: {
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column' as const,
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '0.1em',
+    },
+    splashRow: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.1em',
+    },
+    splashOtherIcon: {
+        width: '0.45em',
+        height: '0.45em',
+        objectFit: 'contain' as const,
+    },
+    anyWrap: {
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    anyCluster: {
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr',
+        gap: '0.05em',
+    },
+    anyIcon: {
+        width: '0.85em',
+        height: '0.85em',
+        objectFit: 'contain' as const,
+    },
+};
+
+export default BaseTilePreview;

--- a/src/app/_components/_sharedcomponents/OpponentPreferences/EditArchetypeDialog.tsx
+++ b/src/app/_components/_sharedcomponents/OpponentPreferences/EditArchetypeDialog.tsx
@@ -1,0 +1,545 @@
+import React, { useState } from 'react';
+import {
+    Autocomplete,
+    Box,
+    FormControlLabel,
+    IconButton,
+    MenuItem,
+    Radio,
+    RadioGroup,
+    Select,
+    TextField,
+    Typography,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
+import { CardStyle } from '@/app/_components/_sharedcomponents/Cards/CardTypes';
+import { Aspect, BaseConstraint, IBaseTypeOption, OpponentArchetype } from '@/app/_constants/constants';
+import BaseTilePreview from './BaseTilePreview';
+import {
+    BASE_ASPECTS,
+    BaseConstraintKind,
+    LeaderOption,
+    aspectHasIcon,
+    aspectIconUrl,
+    baseTileKindFor,
+    baseTypeDisplayName,
+    baseTypeFilter,
+    capitalize,
+    cardImageUrl,
+    getConstraintKind,
+    leaderLabel,
+    pluckOptionProps,
+} from './utils';
+
+const BASE_CONSTRAINT_KIND_OPTIONS: { value: BaseConstraintKind; label: string }[] = [
+    { value: 'any', label: 'Any base' },
+    { value: 'aspect', label: 'Any base of aspect' },
+    { value: 'baseType', label: 'Specific base type' },
+];
+
+interface IEditArchetypeDialogProps {
+    draft: OpponentArchetype;
+    leaders: LeaderOption[];
+    baseTypes: IBaseTypeOption[];
+    baseTypesByJoinedIds: Map<string, IBaseTypeOption>;
+    leaderById: Map<string, LeaderOption>;
+    setDraft: (next: OpponentArchetype) => void;
+    onCancel: () => void;
+    onCommit: () => void;
+    isDuplicate: boolean;
+}
+
+const EditArchetypeDialog: React.FC<IEditArchetypeDialogProps> = ({
+    draft,
+    leaders,
+    baseTypes,
+    baseTypesByJoinedIds,
+    leaderById,
+    setDraft,
+    onCancel,
+    onCommit,
+    isDuplicate,
+}) => {
+    // New archetypes start with no base-kind selected; reopening an existing
+    // archetype pre-selects from its saved constraint (or 'any' if absent).
+    const [selectedKind, setSelectedKind] = useState<BaseConstraintKind | null>(
+        () => (draft.leaderId === '' && draft.baseConstraint === undefined ? null : getConstraintKind(draft.baseConstraint)),
+    );
+    const kind = selectedKind ?? getConstraintKind(draft.baseConstraint);
+    const selectedLeader = leaderById.get(draft.leaderId) ?? null;
+    const selectedBaseTypeKey = draft.baseConstraint?.kind === 'baseType'
+        ? draft.baseConstraint.baseIds.slice().sort().join('|')
+        : null;
+    const selectedBaseType = selectedBaseTypeKey ? (baseTypesByJoinedIds.get(selectedBaseTypeKey) ?? null) : null;
+    const selectedAspect = draft.baseConstraint?.kind === 'aspect' ? draft.baseConstraint.aspect : Aspect.Vigilance;
+
+    const leaderImageUrl = selectedLeader ? cardImageUrl(selectedLeader.id, CardStyle.PlainLeader) : null;
+    const uniqueBaseImageUrl = selectedBaseType && selectedBaseType.baseIds.length === 1
+        ? cardImageUrl(selectedBaseType.id)
+        : null;
+
+    const onLeaderChange = (next: LeaderOption | null) => {
+        if (!next) return;
+        setDraft({ ...draft, leaderId: next.id });
+    };
+    const onKindChange = (nextKind: BaseConstraintKind) => {
+        setSelectedKind(nextKind);
+        if (nextKind === 'any') {
+            setDraft({ ...draft, baseConstraint: undefined });
+            return;
+        }
+        if (nextKind === 'aspect') {
+            setDraft({ ...draft, baseConstraint: { kind: 'aspect', aspect: selectedAspect } });
+            return;
+        }
+        const firstType = baseTypes[0];
+        if (!firstType) return;
+        const next: BaseConstraint = { kind: 'baseType', baseIds: firstType.baseIds };
+        setDraft({ ...draft, baseConstraint: next });
+    };
+    const onAspectChange = (nextAspect: Aspect) => {
+        setDraft({ ...draft, baseConstraint: { kind: 'aspect', aspect: nextAspect } });
+    };
+    const onBaseTypeChange = (next: IBaseTypeOption | null) => {
+        if (!next) return;
+        setDraft({ ...draft, baseConstraint: { kind: 'baseType', baseIds: next.baseIds } });
+    };
+
+    const basePreviewCaption =
+        selectedKind === null ? 'Select a base' :
+            kind === 'aspect' ? `Any ${capitalize(selectedAspect)} base` :
+                kind === 'baseType' && selectedBaseType ? baseTypeDisplayName(selectedBaseType) :
+                    'Any base';
+
+    const previewTileKind = baseTileKindFor(draft.baseConstraint, selectedBaseType);
+    const previewTileAspects: Aspect[] = kind === 'aspect'
+        ? [selectedAspect]
+        : selectedBaseType?.aspects ?? [];
+
+    // ----------------------Styles-----------------------------//
+    const styles = {
+        overlay: {
+            position: 'fixed' as const,
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            zIndex: 1000,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+        },
+        dialog: {
+            padding: '2rem',
+            borderRadius: '15px',
+            border: '2px solid transparent',
+            background: 'linear-gradient(#0F1F27, #030C13) padding-box, linear-gradient(to top, #30434B, #50717D) border-box',
+            width: '560px',
+            maxWidth: '92%',
+            maxHeight: '92vh',
+            overflow: 'auto',
+            position: 'relative' as const,
+            display: 'flex',
+            flexDirection: 'column' as const,
+            gap: '1rem',
+        },
+        preview: {
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'center',
+            gap: '1rem',
+            marginBottom: '0.5rem',
+            flexWrap: 'wrap' as const,
+        },
+        previewSlot: {
+            flex: '1 1 12rem',
+            display: 'flex',
+            flexDirection: 'column' as const,
+            alignItems: 'center',
+            gap: '0.5rem',
+            minWidth: 0,
+            maxWidth: '14rem',
+        },
+        previewImage: {
+            width: '100%',
+            maxWidth: '14rem',
+            aspectRatio: '7 / 5',
+            backgroundSize: 'contain',
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'center',
+        },
+        previewPlaceholder: {
+            width: '100%',
+            maxWidth: '14rem',
+            aspectRatio: '7 / 5',
+            backgroundColor: 'rgba(255, 255, 255, 0.05)',
+            borderRadius: '6px',
+            border: '1px dashed rgba(255, 255, 255, 0.18)',
+        },
+        previewBadge: {
+            width: '100%',
+            maxWidth: '14rem',
+            aspectRatio: '7 / 5',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: 'rgba(0, 0, 0, 0.35)',
+            borderRadius: '6px',
+            border: '1px solid rgba(255, 255, 255, 0.1)',
+            fontSize: '3.2rem',
+        },
+        previewCaption: {
+            display: 'flex',
+            flexDirection: 'column' as const,
+            alignItems: 'center',
+            gap: '0.15rem',
+            textAlign: 'center' as const,
+        },
+        previewCaptionText: {
+            color: '#fff',
+            fontSize: '0.95em',
+            fontWeight: 500,
+            margin: 0,
+            lineHeight: 1.2,
+        },
+        previewCaptionSub: {
+            color: '#bbbbbb',
+            fontSize: '0.85em',
+            margin: 0,
+            lineHeight: 1.2,
+        },
+        close: {
+            position: 'absolute' as const,
+            top: '0.75rem',
+            right: '0.75rem',
+            color: '#cccccc',
+        },
+        title: {
+            color: 'white',
+            fontSize: '1.25rem',
+            fontWeight: 'bold',
+            textAlign: 'center' as const,
+        },
+        field: {
+            flex: 1,
+            '& .MuiAutocomplete-clearIndicator, & .MuiAutocomplete-popupIndicator': {
+                color: '#ffffff',
+            },
+            '& .MuiSelect-icon': {
+                color: '#ffffff',
+            },
+        },
+        fieldGroup: {
+            display: 'flex',
+            flexDirection: 'column' as const,
+            gap: '0.25rem',
+        },
+        fieldLabel: {
+            color: '#aaaaaa',
+            fontSize: '0.75em',
+            textTransform: 'uppercase' as const,
+            letterSpacing: '0.05em',
+        },
+        radio: {
+            color: '#fff',
+            '&.Mui-checked': { color: '#fff' },
+            '&.Mui-disabled': { color: 'rgba(255, 255, 255, 0.3)' },
+        },
+        radioLabel: {
+            color: '#fff',
+            fontSize: '0.9em',
+        },
+        aspectOption: {
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+        },
+        aspectOptionIcon: {
+            width: '20px',
+            height: '20px',
+            objectFit: 'contain' as const,
+        },
+        autocompletePaper: {
+            backgroundColor: '#394452',
+            color: '#fff',
+        },
+        noOptionsText: {
+            color: '#bbbbbb',
+            fontSize: '0.85em',
+            padding: '0.25rem 0.5rem',
+        },
+        optionLeaderThumb: {
+            width: '3.5rem',
+            height: '2.5rem',
+            backgroundColor: 'rgba(255, 255, 255, 0.04)',
+            backgroundSize: 'contain',
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'center',
+            borderRadius: '3px',
+            flexShrink: 0,
+        },
+        optionBaseTile: {
+            width: '3.5rem',
+            height: '2.5rem',
+            backgroundColor: 'rgba(255, 255, 255, 0.04)',
+            backgroundSize: 'contain',
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'center',
+            borderRadius: '3px',
+            flexShrink: 0,
+            fontSize: '0.875rem',
+        },
+        optionRow: {
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+            minHeight: '36px',
+            py: '0.25rem',
+        },
+        optionLabel: {
+            lineHeight: 1.2,
+            margin: 0,
+            minWidth: 0,
+        },
+        inputThumb: {
+            width: '2.2rem',
+            height: '1.6rem',
+            backgroundColor: 'rgba(255, 255, 255, 0.04)',
+            backgroundSize: 'contain',
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'center',
+            borderRadius: '3px',
+            flexShrink: 0,
+            ml: '4px',
+            fontSize: '0.55rem',
+        },
+        actions: {
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: '0.75rem',
+            marginTop: '0.5rem',
+        },
+        duplicateHint: {
+            color: '#ff9c70',
+            fontSize: '0.85em',
+            textAlign: 'right' as const,
+            marginTop: '0.5rem',
+        },
+    };
+
+    return (
+        <Box sx={styles.overlay} onClick={onCancel}>
+            <Box sx={styles.dialog} onClick={(e) => e.stopPropagation()}>
+                <IconButton sx={styles.close} onClick={onCancel} aria-label="close">
+                    <CloseIcon />
+                </IconButton>
+                <Typography sx={styles.title}>Edit archetype</Typography>
+
+                <Box sx={styles.preview}>
+                    <Box sx={styles.previewSlot}>
+                        {leaderImageUrl ? (
+                            <Box sx={{ ...styles.previewImage, backgroundImage: `url(${leaderImageUrl})` }} />
+                        ) : (
+                            <Box sx={styles.previewPlaceholder} />
+                        )}
+                        <Box sx={styles.previewCaption}>
+                            <Typography sx={styles.previewCaptionText}>
+                                {selectedLeader ? selectedLeader.name : 'Select a leader'}
+                            </Typography>
+                            {selectedLeader?.subtitle && (
+                                <Typography sx={styles.previewCaptionSub}>
+                                    {selectedLeader.subtitle}
+                                </Typography>
+                            )}
+                        </Box>
+                    </Box>
+                    <Box sx={styles.previewSlot}>
+                        {selectedKind === null ? (
+                            <Box sx={styles.previewPlaceholder} />
+                        ) : uniqueBaseImageUrl ? (
+                            <Box sx={{ ...styles.previewImage, backgroundImage: `url(${uniqueBaseImageUrl})` }} />
+                        ) : (
+                            <Box sx={styles.previewBadge}>
+                                <BaseTilePreview kind={previewTileKind} aspects={previewTileAspects} />
+                            </Box>
+                        )}
+                        <Box sx={styles.previewCaption}>
+                            <Typography sx={styles.previewCaptionText}>{basePreviewCaption}</Typography>
+                        </Box>
+                    </Box>
+                </Box>
+
+                <Box sx={styles.fieldGroup}>
+                    <Typography sx={styles.fieldLabel}>Leader</Typography>
+                    <Autocomplete
+                        options={leaders}
+                        value={selectedLeader}
+                        getOptionLabel={leaderLabel}
+                        isOptionEqualToValue={(option, value) => option.id === value.id}
+                        onChange={(_, value) => onLeaderChange(value)}
+                        clearIcon={null}
+                        renderInput={(params) => (
+                            <TextField
+                                {...params}
+                                placeholder="Select leader"
+                                size="small"
+                                InputProps={{
+                                    ...params.InputProps,
+                                    startAdornment: selectedLeader ? (
+                                        <Box sx={{ ...styles.inputThumb, backgroundImage: `url(${cardImageUrl(selectedLeader.id, CardStyle.PlainLeader)})` }} />
+                                    ) : null,
+                                }}
+                            />
+                        )}
+                        sx={styles.field}
+                        noOptionsText={<Typography sx={styles.noOptionsText}>No matches</Typography>}
+                        slotProps={{ paper: { sx: styles.autocompletePaper } }}
+                        renderOption={(props, option) => (
+                            <Box
+                                component="li"
+                                key={option.id}
+                                {...pluckOptionProps(props as React.HTMLAttributes<HTMLLIElement>)}
+                                sx={styles.optionRow}
+                            >
+                                <Box sx={{ ...styles.optionLeaderThumb, backgroundImage: `url(${cardImageUrl(option.id, CardStyle.PlainLeader)})` }} />
+                                <Typography component="span" sx={styles.optionLabel}>{leaderLabel(option)}</Typography>
+                            </Box>
+                        )}
+                    />
+                </Box>
+
+                <Box sx={styles.fieldGroup}>
+                    <Typography sx={styles.fieldLabel}>Base</Typography>
+                    <RadioGroup row value={selectedKind ?? ''} onChange={(_, value) => onKindChange(value as BaseConstraintKind)}>
+                        {BASE_CONSTRAINT_KIND_OPTIONS.map(({ value, label }) => (
+                            <FormControlLabel
+                                key={value}
+                                value={value}
+                                control={<Radio size="small" sx={styles.radio} />}
+                                label={<Typography sx={styles.radioLabel}>{label}</Typography>}
+                            />
+                        ))}
+                    </RadioGroup>
+                </Box>
+
+                {kind === 'aspect' && (
+                    <Box sx={styles.fieldGroup}>
+                        <Typography sx={styles.fieldLabel}>Aspect</Typography>
+                        <Select
+                            value={selectedAspect}
+                            size="small"
+                            fullWidth
+                            onChange={(e) => onAspectChange(e.target.value as Aspect)}
+                            renderValue={(value) => (
+                                <Box component="span" sx={styles.aspectOption}>
+                                    <Box
+                                        component="img"
+                                        src={aspectIconUrl(value)}
+                                        alt={value}
+                                        sx={styles.aspectOptionIcon}
+                                    />
+                                    {capitalize(value)}
+                                </Box>
+                            )}
+                        >
+                            {BASE_ASPECTS.map((aspect) => (
+                                <MenuItem key={aspect} value={aspect}>
+                                    <Box component="span" sx={styles.aspectOption}>
+                                        <Box
+                                            component="img"
+                                            src={aspectIconUrl(aspect)}
+                                            alt={aspect}
+                                            sx={styles.aspectOptionIcon}
+                                        />
+                                        {capitalize(aspect)}
+                                    </Box>
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </Box>
+                )}
+
+                {kind === 'baseType' && (
+                    <Box sx={styles.fieldGroup}>
+                        <Typography sx={styles.fieldLabel}>Base type</Typography>
+                        <Autocomplete
+                            options={baseTypes}
+                            value={selectedBaseType}
+                            getOptionLabel={(option) => (option ? baseTypeDisplayName(option) : '')}
+                            filterOptions={baseTypeFilter}
+                            isOptionEqualToValue={(option, value) => option.id === value.id}
+                            onChange={(_, value) => onBaseTypeChange(value)}
+                            clearIcon={null}
+                            noOptionsText={<Typography sx={styles.noOptionsText}>No matches</Typography>}
+                            slotProps={{ paper: { sx: styles.autocompletePaper } }}
+                            renderInput={(params) => (
+                                <TextField
+                                    {...params}
+                                    placeholder="Select base type"
+                                    size="small"
+                                    InputProps={{
+                                        ...params.InputProps,
+                                        startAdornment: selectedBaseType ? (
+                                            selectedBaseType.kind === 'unique' ? (
+                                                <Box sx={{ ...styles.inputThumb, backgroundImage: `url(${cardImageUrl(selectedBaseType.id)})` }} />
+                                            ) : (
+                                                <Box sx={styles.inputThumb}>
+                                                    <BaseTilePreview
+                                                        kind={selectedBaseType.kind}
+                                                        aspects={(selectedBaseType.aspects ?? []).filter(aspectHasIcon)}
+                                                    />
+                                                </Box>
+                                            )
+                                        ) : null,
+                                    }}
+                                />
+                            )}
+                            sx={styles.field}
+                            renderOption={(props, option) => (
+                                <Box
+                                    component="li"
+                                    key={option.id}
+                                    {...pluckOptionProps(props as React.HTMLAttributes<HTMLLIElement>)}
+                                    sx={styles.optionRow}
+                                >
+                                    {option.kind === 'unique' ? (
+                                        <Box sx={{ ...styles.optionBaseTile, backgroundImage: `url(${cardImageUrl(option.id)})` }} />
+                                    ) : (
+                                        <Box sx={styles.optionBaseTile}>
+                                            <BaseTilePreview
+                                                kind={option.kind}
+                                                aspects={(option.aspects ?? []).filter(aspectHasIcon)}
+                                            />
+                                        </Box>
+                                    )}
+                                    <Typography component="span" sx={styles.optionLabel}>
+                                        {baseTypeDisplayName(option)}
+                                    </Typography>
+                                </Box>
+                            )}
+                        />
+                    </Box>
+                )}
+
+                {isDuplicate && (
+                    <Typography sx={styles.duplicateHint}>
+                        An archetype with this leader and base is already in your list.
+                    </Typography>
+                )}
+                <Box sx={styles.actions}>
+                    <PreferenceButton variant="standard" text="Cancel" buttonFnc={onCancel} />
+                    <PreferenceButton
+                        variant="standard"
+                        text="Done"
+                        buttonFnc={onCommit}
+                        disabled={!draft.leaderId || selectedKind === null || isDuplicate}
+                    />
+                </Box>
+            </Box>
+        </Box>
+    );
+};
+
+export default EditArchetypeDialog;

--- a/src/app/_components/_sharedcomponents/OpponentPreferences/OpponentPreferencesEditor.tsx
+++ b/src/app/_components/_sharedcomponents/OpponentPreferences/OpponentPreferencesEditor.tsx
@@ -1,0 +1,260 @@
+'use client';
+import React, { useState } from 'react';
+import { Box, Typography } from '@mui/material';
+import ConfirmationDialog from '@/app/_components/_sharedcomponents/DeckPage/ConfirmationDialog';
+import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
+import EditArchetypeDialog from '@/app/_components/_sharedcomponents/OpponentPreferences/EditArchetypeDialog';
+import ArchetypeRow from '@/app/_components/_sharedcomponents/OpponentPreferences/ArchetypeRow';
+import {
+    archetypeRowBaseAspects,
+    archetypesEqual,
+    resolveBaseType,
+} from '@/app/_components/_sharedcomponents/OpponentPreferences/utils';
+import {
+    MatchPreferences,
+    OpponentArchetype,
+} from '@/app/_constants/constants';
+import { loadMatchPreferences, saveMatchPreferences } from '@/app/_utils/matchPreferences';
+import { useArchetypeLookup } from '@/app/_utils/archetypeLookup';
+
+/**
+ * Body of the opponent-preferences UI. Reads/writes localStorage and owns its
+ * own edit state. Leader / base reference data comes from the shared
+ * useArchetypeLookup hook so the create-lobby modal doesn't pay a second fetch.
+ */
+const OpponentPreferencesEditor: React.FC = () => {
+    const lookup = useArchetypeLookup();
+    const [prefs, setPrefs] = useState<MatchPreferences>(() => loadMatchPreferences());
+    const [selectedIndices, setSelectedIndices] = useState<number[]>([]);
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState<boolean>(false);
+    const [editingIndex, setEditingIndex] = useState<number | null>(null);
+    const [editingDraft, setEditingDraft] = useState<OpponentArchetype | null>(null);
+
+    const persist = (next: MatchPreferences) => {
+        setPrefs(next);
+        saveMatchPreferences(next);
+    };
+
+    const addArchetype = () => {
+        setEditingIndex(null);
+        setEditingDraft({ leaderId: '' });
+    };
+
+    const openEditDialog = (index: number) => {
+        setEditingIndex(index);
+        setEditingDraft({ ...prefs.allowedArchetypes[index] });
+    };
+
+    const closeEditDialog = () => {
+        setEditingIndex(null);
+        setEditingDraft(null);
+    };
+
+    const commitEditDialog = () => {
+        if (editingDraft === null) {
+            closeEditDialog();
+            return;
+        }
+        let updated: OpponentArchetype[];
+        if (editingIndex === null) {
+            updated = [...prefs.allowedArchetypes, editingDraft];
+        } else {
+            updated = prefs.allowedArchetypes.slice();
+            updated[editingIndex] = editingDraft;
+        }
+        persist({ ...prefs, allowedArchetypes: updated });
+        closeEditDialog();
+    };
+
+    const draftIsDuplicate = editingDraft !== null && prefs.allowedArchetypes.some(
+        (other, i) => i !== editingIndex && archetypesEqual(other, editingDraft),
+    );
+
+    const toggleSelection = (index: number) => {
+        setSelectedIndices((prev) => (
+            prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index]
+        ));
+    };
+
+    const deleteSelected = () => {
+        const removeSet = new Set(selectedIndices);
+        const updated = prefs.allowedArchetypes.filter((_, i) => !removeSet.has(i));
+        persist({ ...prefs, allowedArchetypes: updated });
+        setSelectedIndices([]);
+        setDeleteDialogOpen(false);
+    };
+
+    const setArchetypeEnabled = (index: number, enabled: boolean) => {
+        const updated = prefs.allowedArchetypes.slice();
+        updated[index] = { ...updated[index], enabled };
+        persist({ ...prefs, allowedArchetypes: updated });
+    };
+
+    const totalCount = prefs.allowedArchetypes.length;
+    const enabledCount = prefs.allowedArchetypes.filter((a) => a.enabled !== false).length;
+    const allEnabled = totalCount > 0 && enabledCount === totalCount;
+    const setAllEnabled = (enabled: boolean) => {
+        persist({
+            ...prefs,
+            allowedArchetypes: prefs.allowedArchetypes.map((a) => ({ ...a, enabled })),
+        });
+    };
+
+    const styles = {
+        container: {
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '1rem',
+            color: '#fff',
+        },
+        muted: {
+            color: '#bbbbbb',
+        },
+        emptyState: {
+            padding: '2rem',
+            borderRadius: '12px',
+            backgroundColor: 'rgba(0, 0, 0, 0.35)',
+            border: '1px dashed rgba(255, 255, 255, 0.18)',
+            textAlign: 'center',
+        },
+        toolbar: {
+            width: '100%',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: '1rem',
+            flexWrap: 'wrap' as const,
+        },
+        toolbarGroup: {
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.75rem',
+            flexWrap: 'wrap' as const,
+        },
+        bulkActionButton: {
+            backgroundColor: 'rgba(255, 255, 255, 0.06)',
+            border: '1px solid rgba(255, 255, 255, 0.18)',
+            fontSize: '0.85rem',
+            pt: '6px',
+            pb: '6px',
+            '&:hover': {
+                backgroundColor: 'rgba(255, 255, 255, 0.12)',
+                boxShadow: 'none',
+            },
+        },
+        bulkEnableStatus: {
+            color: '#cccccc',
+            fontSize: '0.9em',
+        },
+        rowList: {
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(24rem, 1fr))',
+            gap: '8px 12px',
+            overflowY: 'auto',
+            maxHeight: '60vh',
+        },
+    };
+
+    if (!lookup) {
+        return (
+            <Box sx={styles.container}>
+                <Typography sx={styles.muted}>Loading leaders and bases…</Typography>
+            </Box>
+        );
+    }
+
+    return (
+        <Box sx={styles.container}>
+            <Box sx={styles.toolbar}>
+                <Box sx={styles.toolbarGroup}>
+                    <PreferenceButton
+                        variant="standard"
+                        text="Add archetype"
+                        buttonFnc={addArchetype}
+                        disabled={lookup.leaders.length === 0}
+                    />
+                    {totalCount > 0 && (
+                        <>
+                            <PreferenceButton
+                                variant="standard"
+                                text="Enable all"
+                                buttonFnc={() => setAllEnabled(true)}
+                                disabled={allEnabled}
+                                sx={styles.bulkActionButton}
+                            />
+                            <PreferenceButton
+                                variant="standard"
+                                text="Disable all"
+                                buttonFnc={() => setAllEnabled(false)}
+                                disabled={enabledCount === 0}
+                                sx={styles.bulkActionButton}
+                            />
+                            <Typography sx={styles.bulkEnableStatus}>
+                                {enabledCount} of {totalCount} enabled
+                            </Typography>
+                        </>
+                    )}
+                </Box>
+                {totalCount > 0 && (
+                    <PreferenceButton
+                        variant="concede"
+                        text={'Delete archetype(s)'}
+                        buttonFnc={() => setDeleteDialogOpen(true)}
+                        disabled={selectedIndices.length === 0}
+                    />
+                )}
+            </Box>
+
+            {prefs.allowedArchetypes.length === 0 ? (
+                <Box sx={styles.emptyState}>
+                    <Typography sx={styles.muted}>
+                        No archetypes added yet. Click {'“'}Add archetype{'”'} above to start filtering.
+                    </Typography>
+                </Box>
+            ) : (
+                <Box sx={styles.rowList}>
+                    {prefs.allowedArchetypes.map((archetype, index) => {
+                        const baseType = resolveBaseType(archetype.baseConstraint, lookup.baseTypesByJoinedIds);
+                        return (
+                            <ArchetypeRow
+                                key={index}
+                                archetype={archetype}
+                                isSelected={selectedIndices.includes(index)}
+                                leader={lookup.leaderById.get(archetype.leaderId) ?? null}
+                                baseType={baseType}
+                                baseAspects={archetypeRowBaseAspects(archetype.baseConstraint, baseType)}
+                                onToggleSelection={() => toggleSelection(index)}
+                                onToggleEnabled={(enabled) => setArchetypeEnabled(index, enabled)}
+                                onEdit={() => openEditDialog(index)}
+                            />
+                        );
+                    })}
+                </Box>
+            )}
+
+            <ConfirmationDialog
+                open={deleteDialogOpen}
+                title="Delete Archetypes"
+                message={`Are you sure you want to delete ${selectedIndices.length} archetype${selectedIndices.length === 1 ? '' : 's'}? This action cannot be undone.`}
+                onCancel={() => setDeleteDialogOpen(false)}
+                onConfirm={deleteSelected}
+                confirmButtonText="Delete"
+            />
+            {editingDraft !== null && (
+                <EditArchetypeDialog
+                    draft={editingDraft}
+                    leaders={lookup.leaders}
+                    baseTypes={lookup.baseTypes}
+                    baseTypesByJoinedIds={lookup.baseTypesByJoinedIds}
+                    leaderById={lookup.leaderById}
+                    setDraft={setEditingDraft}
+                    onCancel={closeEditDialog}
+                    onCommit={commitEditDialog}
+                    isDuplicate={draftIsDuplicate}
+                />
+            )}
+        </Box>
+    );
+};
+
+export default OpponentPreferencesEditor;

--- a/src/app/_components/_sharedcomponents/OpponentPreferences/OpponentPreferencesModal.tsx
+++ b/src/app/_components/_sharedcomponents/OpponentPreferences/OpponentPreferencesModal.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import OverlayDialog from '@/app/_components/_sharedcomponents/OverlayDialog/OverlayDialog';
+import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
+import OpponentPreferencesEditor from './OpponentPreferencesEditor';
+
+interface IOpponentPreferencesModalProps {
+    open: boolean;
+    onClose: () => void;
+}
+
+const OpponentPreferencesModal: React.FC<IOpponentPreferencesModalProps> = ({ open, onClose }) => {
+    if (!open) return null;
+
+    const styles = {
+        heading: { fontWeight: 600, color: '#fff', paddingRight: '2rem' },
+        intro: { color: '#cccccc', maxWidth: '720px' },
+        footer: { display: 'flex', justifyContent: 'flex-end', marginTop: '0.5rem' },
+    };
+
+    return (
+        <OverlayDialog onClose={onClose}>
+            <Typography variant="h4" sx={styles.heading}>Opponent Preferences</Typography>
+            <Typography sx={styles.intro}>
+                Add and manage the opponent archetypes you{'’'}ll accept into your filtered
+                lobby. Each archetype is a leader + base combination; toggle them on or off
+                without removing them to fine-tune the filter. Preferences are saved
+                automatically and snapshot into the lobby when you create it.
+            </Typography>
+
+            <OpponentPreferencesEditor />
+
+            <Box sx={styles.footer}>
+                <PreferenceButton text="Done" buttonFnc={onClose} variant="standard" />
+            </Box>
+        </OverlayDialog>
+    );
+};
+
+export default OpponentPreferencesModal;

--- a/src/app/_components/_sharedcomponents/OpponentPreferences/ReadOnlyArchetypeList.tsx
+++ b/src/app/_components/_sharedcomponents/OpponentPreferences/ReadOnlyArchetypeList.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import ArchetypeRow from './ArchetypeRow';
+import { archetypeRowBaseAspects, resolveBaseType } from './utils';
+import { OpponentArchetype } from '@/app/_constants/constants';
+import { IArchetypeLookup } from '@/app/_utils/archetypeLookup';
+
+interface IReadOnlyArchetypeListProps {
+    archetypes: OpponentArchetype[];
+    lookup: IArchetypeLookup | null;
+    maxHeight?: string;
+}
+
+/**
+ * Grid of read-only ArchetypeRow entries. Used by both the lobby browser's
+ * "Allowed Archetypes" detail modal and the JoinFilteredLobbyModal.
+ */
+const ReadOnlyArchetypeList: React.FC<IReadOnlyArchetypeListProps> = ({ archetypes, lookup, maxHeight = '60vh' }) => {
+    const styles = {
+        list: {
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(18rem, 1fr))',
+            gap: '6px 10px',
+            maxHeight,
+            overflowY: 'auto' as const,
+        },
+    };
+
+    return (
+        <Box sx={styles.list}>
+            {archetypes.map((arch, i) => {
+                const baseType = resolveBaseType(arch.baseConstraint, lookup?.baseTypesByJoinedIds ?? new Map());
+                return (
+                    <ArchetypeRow
+                        key={i}
+                        archetype={arch}
+                        isSelected={false}
+                        leader={lookup?.leaderById.get(arch.leaderId) ?? null}
+                        baseType={baseType}
+                        baseAspects={archetypeRowBaseAspects(arch.baseConstraint, baseType)}
+                        onToggleSelection={() => undefined}
+                        onToggleEnabled={() => undefined}
+                        onEdit={() => undefined}
+                        isReadOnly
+                    />
+                );
+            })}
+        </Box>
+    );
+};
+
+export default ReadOnlyArchetypeList;

--- a/src/app/_components/_sharedcomponents/OpponentPreferences/utils.ts
+++ b/src/app/_components/_sharedcomponents/OpponentPreferences/utils.ts
@@ -1,0 +1,164 @@
+import type React from 'react';
+import { createFilterOptions } from '@mui/material/Autocomplete';
+import { Aspect, BaseConstraint, IBaseTypeOption } from '@/app/_constants/constants';
+import { CardStyle } from '@/app/_components/_sharedcomponents/Cards/CardTypes';
+import { s3CardImageURL } from '@/app/_utils/s3Utils';
+import type { BaseTileKind } from './BaseTilePreview';
+
+export interface LeaderOption {
+    name: string;
+    id: string;
+    subtitle?: string;
+}
+
+export type BaseConstraintKind = 'any' | 'aspect' | 'baseType';
+
+// Heroism / Villainy are alignment aspects on leaders/units, not bases.
+export const BASE_ASPECTS: Aspect[] = [
+    Aspect.Aggression,
+    Aspect.Command,
+    Aspect.Cunning,
+    Aspect.Vigilance,
+];
+
+const BASE_ASPECT_SET: Set<string> = new Set(BASE_ASPECTS);
+
+export const aspectIconUrl = (aspect: string) => `/aspect-icons/aspect-${aspect}.webp`;
+
+export function aspectHasIcon(aspect: string | null | undefined): aspect is Aspect {
+    return !!aspect && BASE_ASPECT_SET.has(aspect.toLowerCase());
+}
+
+export function getConstraintKind(constraint: BaseConstraint | undefined): BaseConstraintKind {
+    if (!constraint) {
+        return 'any';
+    }
+    return constraint.kind;
+}
+
+export function leaderLabel(option: LeaderOption | null): string {
+    if (!option) {
+        return '';
+    }
+    return option.subtitle ? `${option.name} - ${option.subtitle}` : option.name;
+}
+
+export function capitalize(value: string): string {
+    if (value.length === 0) {
+        return value;
+    }
+    return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+export function baseTypeDisplayName(option: IBaseTypeOption): string {
+    switch (option.kind) {
+        case 'unique': return option.name;
+        case 'standard': return 'Standard 30HP';
+        case 'force': return 'Force 28HP';
+        case 'splash': return 'Splash 27HP';
+        case 'unknown': return 'Other';
+    }
+}
+
+// Filter on display name so 'agg' doesn't match every Aggression group.
+export const baseTypeFilter = createFilterOptions<IBaseTypeOption>({
+    stringify: baseTypeDisplayName,
+});
+
+// Wrap s3CardImageURL for the common case where we only have a card id
+// (no full ICardData/ISetCode payload). The shape-check inside s3Utils
+// handles a bare {id} at runtime.
+export function cardImageUrl(id: string, style?: CardStyle): string {
+    return s3CardImageURL({ id, count: 0 } as never, style);
+}
+
+// Strip MUI Autocomplete's auto-generated `key` from the rendered <li>
+// props — React needs the key passed explicitly via JSX, not through a
+// spread. Returns the rest of the props ready for spreading.
+export function pluckOptionProps(
+    props: React.HTMLAttributes<HTMLLIElement> & { key?: React.Key },
+): React.HTMLAttributes<HTMLLIElement> {
+    const { key, ...rest } = props;
+    void key;
+    return rest;
+}
+
+// User-facing title for the "base" half of an archetype row, given the
+// constraint and any resolved baseType for it.
+export function formatBaseTitle(
+    constraint: BaseConstraint | undefined,
+    selectedBaseType: IBaseTypeOption | null,
+): string {
+    if (!constraint) {
+        return 'Any base';
+    }
+    if (constraint.kind === 'aspect') {
+        return `Any ${capitalize(constraint.aspect)}`;
+    }
+    if (selectedBaseType) {
+        return baseTypeDisplayName(selectedBaseType);
+    }
+    return `${constraint.baseIds.length} bases`;
+}
+
+// Two archetypes are equal iff they target the same leader+base constraint.
+// `enabled` doesn't affect identity — the user toggles it independently.
+function constraintsEqual(a: BaseConstraint | undefined, b: BaseConstraint | undefined): boolean {
+    if (!a && !b) return true;
+    if (!a || !b) return false;
+    if (a.kind !== b.kind) return false;
+    if (a.kind === 'aspect' && b.kind === 'aspect') {
+        return a.aspect === b.aspect;
+    }
+    if (a.kind === 'baseType' && b.kind === 'baseType') {
+        return a.baseIds.slice().sort().join('|') === b.baseIds.slice().sort().join('|');
+    }
+    return false;
+}
+
+export function archetypesEqual(a: { leaderId: string; baseConstraint?: BaseConstraint }, b: { leaderId: string; baseConstraint?: BaseConstraint }): boolean {
+    return a.leaderId === b.leaderId && constraintsEqual(a.baseConstraint, b.baseConstraint);
+}
+
+// Resolve which BaseTilePreview variant to render for an archetype. Callers
+// pass the constraint and the resolved baseType (if applicable) — unique
+// base types are rendered as a thumbnail by the caller, not the tile.
+export function baseTileKindFor(
+    constraint: BaseConstraint | undefined,
+    selectedBaseType: IBaseTypeOption | null,
+): BaseTileKind {
+    if (!constraint) {
+        return 'any';
+    }
+    if (constraint.kind === 'aspect') {
+        return 'aspect';
+    }
+    if (!selectedBaseType || selectedBaseType.kind === 'unique') {
+        return 'standard';
+    }
+    return selectedBaseType.kind;
+}
+
+// Look up the IBaseTypeOption that backs a baseType constraint, if any.
+export function resolveBaseType(
+    constraint: BaseConstraint | undefined,
+    baseTypesByJoinedIds: Map<string, IBaseTypeOption>,
+): IBaseTypeOption | null {
+    if (constraint?.kind !== 'baseType') {
+        return null;
+    }
+    const key = constraint.baseIds.slice().sort().join('|');
+    return baseTypesByJoinedIds.get(key) ?? null;
+}
+
+// Aspects to render on the base tile for an archetype row: the constraint
+// aspect when kind=aspect, otherwise the resolved baseType's aspects.
+export function archetypeRowBaseAspects(
+    constraint: BaseConstraint | undefined,
+    baseType: IBaseTypeOption | null,
+): Aspect[] {
+    if (constraint?.kind === 'aspect') {
+        return [constraint.aspect];
+    }
+    return (baseType?.aspects ?? []).filter(aspectHasIcon);
+}

--- a/src/app/_components/_sharedcomponents/OverlayDialog/OverlayDialog.tsx
+++ b/src/app/_components/_sharedcomponents/OverlayDialog/OverlayDialog.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Box, IconButton, Portal } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+
+interface IOverlayDialogProps {
+    onClose: () => void;
+    width?: string;
+    children: React.ReactNode;
+}
+
+/**
+ * Shared shell for the filtered-lobby modals: Portal-mounted backdrop +
+ * gradient-bordered dialog box + top-right close button. Portaling lets
+ * position:fixed escape transform-creating ancestors (the homepage's
+ * three-column layout otherwise traps fixed-positioned descendants).
+ */
+const OverlayDialog: React.FC<IOverlayDialogProps> = ({ onClose, width = '80rem', children }) => {
+    const styles = {
+        overlay: {
+            position: 'fixed' as const,
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            zIndex: 1000,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+        },
+        dialog: {
+            padding: '2rem',
+            borderRadius: '15px',
+            border: '2px solid transparent',
+            background: 'linear-gradient(#0F1F27, #030C13) padding-box, linear-gradient(to top, #30434B, #50717D) border-box',
+            width,
+            maxWidth: '92vw',
+            maxHeight: '92vh',
+            overflow: 'auto',
+            position: 'relative' as const,
+            display: 'flex',
+            flexDirection: 'column' as const,
+            gap: '1rem',
+        },
+        closeButton: {
+            position: 'absolute' as const,
+            top: '0.5rem',
+            right: '0.5rem',
+            color: '#aaa',
+            '&:hover': { color: '#fff' },
+        },
+    };
+
+    return (
+        <Portal>
+            <Box sx={styles.overlay} onClick={onClose}>
+                <Box sx={styles.dialog} onClick={(e) => e.stopPropagation()}>
+                    <IconButton sx={styles.closeButton} onClick={onClose} aria-label="Close">
+                        <CloseIcon />
+                    </IconButton>
+                    {children}
+                </Box>
+            </Box>
+        </Portal>
+    );
+};
+
+export default OverlayDialog;

--- a/src/app/_constants/constants.ts
+++ b/src/app/_constants/constants.ts
@@ -39,6 +39,52 @@ export interface IMatchConfiguration {
     gamesToWinMode: GamesToWinMode;
 }
 
+// Wire-format mirror of forceteki/server/gamenode/MatchmakingRules.ts.
+export enum Aspect {
+    Aggression = 'aggression',
+    Command = 'command',
+    Cunning = 'cunning',
+    Heroism = 'heroism',
+    Vigilance = 'vigilance',
+    Villainy = 'villainy',
+}
+
+export type BaseConstraint =
+    | { kind: 'aspect'; aspect: Aspect }
+    | { kind: 'baseType'; baseIds: string[] };
+
+export type BaseTypeKind = 'standard' | 'force' | 'splash' | 'unknown' | 'unique';
+
+interface IBaseTypeCommon {
+    id: string;
+    aspects: Aspect[] | null;
+    baseIds: string[];
+}
+
+export type IBaseTypeOption =
+    | (IBaseTypeCommon & { kind: 'unique'; name: string })
+    | (IBaseTypeCommon & { kind: 'standard' | 'force' | 'splash' | 'unknown' });
+
+export interface OpponentArchetype {
+    leaderId: string;
+    baseConstraint?: BaseConstraint;
+
+    /** Defaults to true; `false` keeps the archetype saved but excluded from the filter. */
+    enabled?: boolean;
+}
+
+export interface MatchPreferences {
+    enabled: boolean;
+    allowedArchetypes: OpponentArchetype[];
+}
+
+export const DefaultMatchPreferences: MatchPreferences = {
+    enabled: false,
+    allowedArchetypes: [],
+};
+
+export const MATCH_PREFERENCES_LOCALSTORAGE_KEY = 'matchPreferences';
+
 export const DefaultFormat: IMatchConfiguration = {
     format: SwuGameFormat.Premier,
     cardPool: CardPool.Current,

--- a/src/app/_utils/archetypeLookup.ts
+++ b/src/app/_utils/archetypeLookup.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { IBaseTypeOption } from '@/app/_constants/constants';
+import {
+    baseTypeDisplayName,
+    LeaderOption,
+    leaderLabel,
+} from '@/app/_components/_sharedcomponents/OpponentPreferences/utils';
+
+export interface IArchetypeLookup {
+    leaders: LeaderOption[];
+    baseTypes: IBaseTypeOption[];
+    leaderById: Map<string, LeaderOption>;
+    baseTypesByJoinedIds: Map<string, IBaseTypeOption>;
+}
+
+let cache: IArchetypeLookup | null = null;
+let inflight: Promise<IArchetypeLookup> | null = null;
+
+async function loadOnce(): Promise<IArchetypeLookup> {
+    if (cache) {
+        return cache;
+    }
+    if (!inflight) {
+        inflight = (async () => {
+            const [leadersRes, baseTypesRes] = await Promise.all([
+                fetch(`${process.env.NEXT_PUBLIC_ROOT_URL}/api/all-leaders`),
+                fetch(`${process.env.NEXT_PUBLIC_ROOT_URL}/api/all-base-types`),
+            ]);
+            if (!leadersRes.ok || !baseTypesRes.ok) {
+                throw new Error(`Failed to load leaders/base types (${leadersRes.status}/${baseTypesRes.status})`);
+            }
+            const leaders: LeaderOption[] = await leadersRes.json();
+            const baseTypes: IBaseTypeOption[] = await baseTypesRes.json();
+            leaders.sort((a, b) => leaderLabel(a).localeCompare(leaderLabel(b)));
+            baseTypes.sort((a, b) => {
+                const aspectCmp = (a.aspects ?? []).join('+').localeCompare((b.aspects ?? []).join('+'));
+                if (aspectCmp !== 0) return aspectCmp;
+                return baseTypeDisplayName(a).localeCompare(baseTypeDisplayName(b));
+            });
+            const leaderById = new Map(leaders.map((l) => [l.id, l]));
+            const baseTypesByJoinedIds = new Map<string, IBaseTypeOption>();
+            for (const bt of baseTypes) {
+                baseTypesByJoinedIds.set(bt.baseIds.slice().sort().join('|'), bt);
+            }
+            cache = { leaders, baseTypes, leaderById, baseTypesByJoinedIds };
+            return cache;
+        })();
+    }
+    return inflight;
+}
+
+/**
+ * Shared, app-wide lookup of leaders + base types for rendering archetype
+ * filter rules. First caller triggers the fetch; subsequent callers reuse
+ * the cached maps.
+ */
+export function useArchetypeLookup(): IArchetypeLookup | null {
+    const [data, setData] = useState<IArchetypeLookup | null>(cache);
+    useEffect(() => {
+        if (data) return;
+        let cancelled = false;
+        loadOnce().then((result) => {
+            if (!cancelled) setData(result);
+        }).catch(() => {
+            // swallow; consumers fall back to ids
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, [data]);
+    return data;
+}

--- a/src/app/_utils/matchPreferences.ts
+++ b/src/app/_utils/matchPreferences.ts
@@ -1,0 +1,36 @@
+import { DefaultMatchPreferences, MATCH_PREFERENCES_LOCALSTORAGE_KEY, MatchPreferences } from '@/app/_constants/constants';
+
+export function loadMatchPreferences(): MatchPreferences {
+    if (typeof window === 'undefined') {
+        return DefaultMatchPreferences;
+    }
+    try {
+        const stored = window.localStorage.getItem(MATCH_PREFERENCES_LOCALSTORAGE_KEY);
+        if (!stored) {
+            return DefaultMatchPreferences;
+        }
+        const parsed = JSON.parse(stored);
+        if (
+            parsed &&
+            typeof parsed === 'object' &&
+            typeof parsed.enabled === 'boolean' &&
+            Array.isArray(parsed.allowedArchetypes)
+        ) {
+            return parsed as MatchPreferences;
+        }
+    } catch {
+        // Malformed localStorage entry; fall through to default.
+    }
+    return DefaultMatchPreferences;
+}
+
+export function saveMatchPreferences(prefs: MatchPreferences): void {
+    if (typeof window === 'undefined') {
+        return;
+    }
+    try {
+        window.localStorage.setItem(MATCH_PREFERENCES_LOCALSTORAGE_KEY, JSON.stringify(prefs));
+    } catch {
+        // Quota / private mode — best-effort.
+    }
+}


### PR DESCRIPTION
## Summary

> Draft — paired with BE draft at https://github.com/SWU-Karabast/forceteki/pull/2391.

Add an opponent-archetype filter to public lobbies: hosts declare allowed leader / base combinations on the create-lobby form, joiners pick a deck before they're admitted.

**Walkthrough (screenshots + flow):** https://pmossman.github.io/karabast-filtered-lobbies-walkthrough/

## What changed

### Host — create-lobby
- New **Public (Filtered)** option on the create-lobby privacy radio. Selecting it reveals a *Manage Opponent Preferences* button + active-archetype count.
- The archetype editor lives in a modal (`OpponentPreferencesModal`) opened from the create-lobby form.
- Submit gated until at least one archetype is enabled; enabled archetypes are snapshotted into the `/api/create-lobby` payload as `archetypeFilter`.

### Browser — lobby list
- `JoinableGame` cards render an **Allowed Decks (N)** button under the host's leader/base preview.
- `ArchetypeFilterDetailModal` shows the host's filter as a read-only list.
- `useArchetypeLookup` hook caches leaders + base types (`/api/all-leaders` + `/api/all-base-types`) once per session for reuse across cards / modals / the editor itself.

### Joiner — join modal
- `JoinFilteredLobbyModal`: lists allowed archetypes, asks for a deck before submit.
- Deck input mirrors the matchmaking-queue UX: *Saved deck* / *New deck link / JSON* radios; saved-decks dropdown with favourites first and `★` prefix.
- Saved decks that don't match the host's filter are kept in the dropdown but disabled with a *"doesn't match filter"* suffix; the modal auto-selects the first matching deck once the lookup loads.
- BE rejection surfaces inline so the joiner can switch decks without leaving the modal.

### Shared components introduced
- `OverlayDialog` — Portal-mounted backdrop + gradient-bordered dialog + close button. Used by the three new modals.
- `ReadOnlyArchetypeList` — the read-only grid of `ArchetypeRow`s used by both the lobby-browser detail modal and the join modal.
- `ArchetypeRow` gains an `isReadOnly` prop (hides checkbox / edit / selection chrome, compact spacing).
- Read-only rows use a **CSS container query** (`container-type: inline-size` + `@container (max-width: 22rem)`) so the row flips between inline (leader + base side-by-side) and stacked layout based on the row's own width
