### PR TITLE
Mobile fixes: columns and order of widgets on the homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,22 +13,28 @@ const Home: React.FC = () => {
             overflow: 'hidden',
         },
         columnContainer: {
-            height: '100vh',
-            padding: '1rem 0.75rem 3rem',
+            height: { xs: 'auto', md: '100vh' },
+            padding: { xs: '23rem 0.75rem 0rem', md: '1rem 0.75rem 2.5rem' },
+            flexDirection: { xs: 'column', md: 'row' },
+            alignItems: { xs: 'center', md: 'flex-end' },
+            gap: { xs: '1rem', md: 0 },
         },
         column: {
             justifyContent: 'center',
-            height: 'calc(100% - 10.5rem)',
+            height: { xs: 'auto', md: 'calc(100% - 10.5rem)' },
             alignSelf: 'end',
             padding: '0 0.75rem',
+            width: '100%',
         },
         disclaimer: {
-            position: 'absolute',
-            bottom: 0,
+            position: { xs: 'relative', md: 'absolute' },
+            bottom: { xs: 'auto', md: 0 },
             width: '100%',
-            padding: '1rem',
+            padding: '0rem 1rem 1rem 1rem',
             textAlign: 'center',
-            fontSize: '0.75rem',
+            fontSize: { xs: '1.4rem', md: '0.75rem' },
+            color: '#FFFFFF',
+            mt: { xs: '1.5rem', md: 0 },
         },
     };
 
@@ -38,13 +44,16 @@ const Home: React.FC = () => {
             <KarabastBanner />
 
             <Grid container size={12} sx={styles.columnContainer}>
-                <Grid size={4} sx={styles.column}>
+                {/* Public Games - Order 3 on Mobile, 1 on Desktop */}
+                <Grid size={{ xs: 12, md: 4 }} order={{ xs: 3, md: 1 }} sx={styles.column}>
                     <PublicGames />
                 </Grid>
-                <Grid size={4} sx={styles.column}>
+                {/* Play Mode - Order 1 on Mobile, 2 on Desktop */}
+                <Grid size={{ xs: 12, md: 4 }} order={{ xs: 1, md: 2 }} sx={styles.column}>
                     <HomePagePlayMode />
                 </Grid>
-                <Grid size={4} sx={styles.column}>
+                {/* News - Order 2 on Mobile, 3 on Desktop */}
+                <Grid size={{ xs: 12, md: 4 }} order={{ xs: 2, md: 3 }} sx={styles.column}>
                     <NewsColumn />
                 </Grid>
             </Grid>


### PR DESCRIPTION
Let's bring @Rballesteros changes little by little.

**First PR**: Columns and order of widgets on the homepage
**Note**: Full screen resolution remains unchanged

# Before

## Ipad Air

<img width="1640" height="2360" alt="localhost_3000_(iPad Air)" src="https://github.com/user-attachments/assets/4f2c5eac-3212-4a7a-a518-dacc300946a7" />

## Iphone 12 Pro
<img width="1170" height="2532" alt="localhost_3000_(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/051538bb-3187-41b5-8134-90dcb1492e6b" />


# After
## Ipad Air
<img width="1640" height="3200" alt="after_localhost_3000_(iPad Air) (1)" src="https://github.com/user-attachments/assets/9ca06ac1-fc75-4319-a258-1ead86dd0be6" />

## Iphone 12 Pro
<img width="1170" height="3909" alt="after_localhost_3000_(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/85bc2205-1054-4e33-9dd4-48c8f3790d9e" />
