### PR TITLE
Fix for the overlapping between the bases and the action prompt on mo…

### DIFF
--- a/src/app/GameBoard/page.tsx
+++ b/src/app/GameBoard/page.tsx
@@ -125,11 +125,14 @@ const GameBoard = () => {
             alignItems: 'center',
             width: '50vw',
             pointerEvents: 'none',
-            zIndex: '1',
+            zIndex: { xs: '2', md: '1' },
         },
         promptStyle: {
             textAlign: 'center',
             fontSize: '1.3em',
+            // media query to detect mobile in landscape mode. be aware that most devices will have 800px wide on landscape
+            // for this case we want to save as much space as possible
+            '@media (orientation: landscape) and (max-width:932px)': { fontSize: '1rem' },
             textShadow: '1px 1px 6px black',
             padding: '0.5rem',
             position: 'relative',


### PR DESCRIPTION
…bile devices

**Change** The action prompt text gets overlapped by the base cards. I changed the z-index and decrease the size a little bit on landscape mode to save some space on the screen

Before
<img width="2532" height="1170" alt="mobile_landscape_no_changes" src="https://github.com/user-attachments/assets/9abbb1f1-b31a-4964-b068-2f29e35f7107" />
After
<img width="2532" height="1170" alt="localhost_3000_GameBoard(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/0b893783-1fb7-4d0d-8637-e7f337753f08" />
