### PR TITLE
Fix preferences page on mobile devices

### DIFF
--- a/src/app/_components/_sharedcomponents/Preferences/PreferencesComponent.tsx
+++ b/src/app/_components/_sharedcomponents/Preferences/PreferencesComponent.tsx
@@ -33,13 +33,14 @@ const PreferencesComponent: React.FC<IPreferenceProps> = ({
             height: '100%',
             backgroundColor: variant ==='gameBoard' ? 'rgba(0, 0, 0, 0.5)' : 'none',
             zIndex: variant === 'homePage' ? 1 : 999,
-            padding: variant === 'homePage' ? '7rem' : '2rem',
+            padding: variant === 'homePage' ? { xs: '7rem 2rem', md:'7rem' } : '2rem',
         },
         overlayStyle:{
             display: isPreferenceOpen ? 'block' : 'none',
             padding: '30px',
             maxWidth: '105em',
-            maxHeight: '65em',
+            // nothing should display outside the popup. use inner scrolls to display the content
+            overflow: 'hidden',
             zIndex: 10,
             backgroundColor: 'rgba(0, 0, 0, 0.8)',
             border: '3px solid transparent',

--- a/src/app/_components/_sharedcomponents/Preferences/_subComponents/VerticalTabs.tsx
+++ b/src/app/_components/_sharedcomponents/Preferences/_subComponents/VerticalTabs.tsx
@@ -17,6 +17,7 @@ import GeneralTab from '@/app/_components/_sharedcomponents/Preferences/Preferen
 import UnsavedChangesDialog from '@/app/_components/_sharedcomponents/Preferences/_subComponents/UnsavedChangesDialog';
 import CosmeticsTab from '../PreferencesSubElementVariants/CosmeticsTab';
 import GameOptionsTab from '../PreferencesSubElementVariants/GameOptionsTab';
+import {useMediaQuery} from "@mui/material";
 
 function tabProps(index: number) {
     return {
@@ -50,6 +51,7 @@ function VerticalTabs({
     const [pendingTabIndex, setPendingTabIndex] = useState<number | null>(null);
     const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
     const { logout } = useUser();
+    const isSmallScreen = useMediaQuery('(max-width: 1280px)');
 
     useEffect(() => {
         const handleBeforeUnload = (e: BeforeUnloadEvent) => {
@@ -155,7 +157,7 @@ function VerticalTabs({
     // ------------------------STYLES------------------------//
     const styles = {
         tabContainer: {
-            width: '20%',
+            width: { xs: 'auto', md: '20%' },
             backgroundColor: 'transparent',
             gap:'1rem',
         },
@@ -179,8 +181,8 @@ function VerticalTabs({
         },
         tabPanelContainer:{
             backgroundColor: 'transparent',
-            width: '80%',
-            pl:9,
+            width: { xs: 'auto', md: '80%' },
+            pl: { xs: 0, md: 9 },
             gap: '20px',
             maxHeight: variant === 'gameBoard' ? 'calc(80vh - 1rem)' : 'calc(100vh - 14rem - 60px)',
             overflowY: 'auto',
@@ -200,10 +202,10 @@ function VerticalTabs({
 
     return (
         <Box
-            sx={{ display: 'flex', background: 'transparent' }}
+            sx={{ display: 'flex', background: 'transparent', flexDirection: { xs: 'column', md: 'row' } }}
         >
             <Tabs
-                orientation="vertical"
+                orientation={isSmallScreen ? 'horizontal' : 'vertical'}
                 variant="scrollable"
                 value={value}
                 onChange={handleChange}


### PR DESCRIPTION
Preferences page doesn't look good on mobile devices

### Current behavior

In-game mobile portrait

<img width="1170" height="2532" alt="in_game_popup_portrait" src="https://github.com/user-attachments/assets/fb5cc5cb-fec1-41c2-90ed-4e176252a153" />

Preference page on mobile
<img width="1170" height="2532" alt="preference_page_portrait" src="https://github.com/user-attachments/assets/59f6d069-3a05-4b01-b300-e267cf3a9b04" />


### New behavior

Preferences page

https://github.com/user-attachments/assets/ae0bafb3-e85e-44d3-9706-ff43d129b0c6

In-game popup (portrait)

<img width="1170" height="2532" alt="mobile_in_game_portrait" src="https://github.com/user-attachments/assets/ee73c760-7bdc-43d2-ba88-b5d966d63000" />



