### PR TITLE
Fix undo button placement on mobile

### DIFF
--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -200,18 +200,21 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar }) 
             </Box>
 
             {(isDev || gameState.undoEnabled) && (!isSpectator) && (<Box sx={styles.quickUndoBox}>
-                <Image
-                    src="/porg1.png"
-                    alt="Highlighted Stats Panel"
-                    width={50}
-                    height={50}
-                    style={{
-                        position:'relative',
-                        left:'35px',
-                        bottom:'28px',
-                        visibility: isUndoHovered ? 'visible' : 'hidden',
-                    }}
-                />
+                <Box sx={{
+                    position:'relative',
+                    left:'35px',
+                    bottom:'28px',
+                    visibility: isUndoHovered ? 'visible' : 'hidden',
+                    '@media (max-width:800px)': { display: 'none' },
+                }}>
+                    <Image
+                        src="/porg1.png"
+                        alt="Highlighted Stats Panel"
+                        width={50}
+                        height={50}
+                    />
+                </Box>
+               
                 <Button
                     variant="contained"
                     onClick={handleUndoButton}


### PR DESCRIPTION
The undo button placement on mobile seems broken. That's because the hidden porg image being shown when hovering the button is taking available space. Since we don't have hover on mobile, we should remove it from rendering, using `display:none` through the usage of media queries (not available via inline styles). 

# Issue 
<img width="350" src="https://github.com/user-attachments/assets/a1bd506e-5591-4f82-a7a1-582cb44e6ec5" />

<img width="700" alt="undo_button_break" src="https://github.com/user-attachments/assets/bdc02e60-c120-4426-92da-ff660f6adb1c" />

# Fix

<img width="350" alt="portrait_fixed" src="https://github.com/user-attachments/assets/3b2dbbbc-2816-4900-aad2-7d39e72fa110" />
