### PR TITLE
Fix chat drawer on mobile

### DIFF
--- a/src/app/GameBoard/page.tsx
+++ b/src/app/GameBoard/page.tsx
@@ -103,7 +103,7 @@ const GameBoard = () => {
     // ----------------------Styles-----------------------------//
     const styles = {
         mainBoxStyle: {
-            pr: sidebarOpen ? 'min(20%, 280px)' : '0',
+            pr: sidebarOpen ? { xs: 0, md: 'min(20%, 280px)' } : '0',
             width: '100%',
             transition: 'padding-right 0.3s ease-in-out',
             height: '100dvh',
@@ -117,7 +117,7 @@ const GameBoard = () => {
         centralPromptContainer: {
             position: 'absolute',
             top: '48.6%',
-            left: sidebarOpen ? 'calc(50vw - min(10%, 140px))' : '50vw',
+            left: sidebarOpen ? { xs: '50vw', md: 'calc(50vw - min(10%, 140px))' } : '50vw',
             transform: 'translate(-50%, -50%)',
             transition: 'left 0.3s ease-in-out',
             display: 'flex',
@@ -156,7 +156,7 @@ const GameBoard = () => {
             position: 'absolute',
             bottom: 0, // Touch bottom edge
             left: '2rem', // Add left margin to constrain width
-            right: sidebarOpen ? 'calc(min(20%, 280px) + 2rem)' : '2rem', // Add right margin to match
+            right: sidebarOpen ? { xs: '2rem', md: 'calc(min(20%, 280px) + 2rem)' } : '2rem', // Add right margin to match
             height: '47dvh', // Reduced height for middle spacing
             backgroundSize: 'cover', // Fill container width, crop overflow edges
             backgroundPosition: 'center center',
@@ -170,7 +170,7 @@ const GameBoard = () => {
             position: 'absolute',
             top: 0, // Touch top edge
             left: '2rem', // Add left margin to constrain width
-            right: sidebarOpen ? 'calc(min(20%, 280px) + 2rem)' : '2rem', // Add right margin to match
+            right: sidebarOpen ? { xs: '2rem', md: 'calc(min(20%, 280px) + 2rem)' } : '2rem', // Add right margin to match
             height: '47dvh', // Reduced height for middle spacing
             backgroundSize: 'cover', // Fill container width, crop overflow edges
             backgroundPosition: 'center center',

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -77,7 +77,7 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar }) 
                 color: '#fff',
                 display: 'flex',
                 flexDirection: 'column',
-                width: 'min(20%, 280px)',
+                width: { xs: '200px', md: 'min(20%, 280px)' },
                 padding: '0.75em',
                 overflow: 'hidden',
             },

--- a/src/app/_components/_sharedcomponents/Preferences/PreferencesComponent.tsx
+++ b/src/app/_components/_sharedcomponents/Preferences/PreferencesComponent.tsx
@@ -29,7 +29,7 @@ const PreferencesComponent: React.FC<IPreferenceProps> = ({
         containerStyle:{
             display: isPreferenceOpen ? 'block' : 'none',
             position: 'absolute',
-            width: sidebarOpen ? 'calc(100% - min(20%, 280px))' : '100%',
+            width: sidebarOpen ? { xs: '100%', md: 'calc(100% - min(20%, 280px))' } : '100%',
             height: '100%',
             backgroundColor: variant ==='gameBoard' ? 'rgba(0, 0, 0, 0.5)' : 'none',
             zIndex: variant === 'homePage' ? 1 : 999,


### PR DESCRIPTION
# Problem

Chat drawer is not looking good when on mobile portrait (screenshot below). I think the drawer shouldn't take space on mobile screen since it's very limited. Instead we make it float on top and make it look bigger so it's easier to read.

<img width="450" src="https://github.com/user-attachments/assets/96b461ba-2715-4dd2-b535-ece3b4d9c016" />


# Fix

https://github.com/user-attachments/assets/389506af-6cd2-4a19-9340-2ca52193b52b


https://github.com/user-attachments/assets/b4087dad-9593-43bf-b910-43df01816271

