### PR TITLE
Create dedicated timer tutorial popup

### DIFF
--- a/src/app/_components/HomePage/HomePagePlayMode.tsx
+++ b/src/app/_components/HomePage/HomePagePlayMode.tsx
@@ -20,14 +20,13 @@ import {
     setReportingDisabledSeenAsync,
     hasUserSeenUndoPopup, 
     markUndoPopupAsSeen,
-    markAnnouncementAsSeen, 
-    shouldShowAnnouncement 
+    hasUserSeenTimerPopup,
+    markTimerPopupAsSeen,
 } from '@/app/_utils/ServerAndLocalStorageUtils';
 import { checkIfModerationExpired } from '@/app/_utils/ModerationUtils';
 import { ModerationFieldState } from '@/app/_contexts/UserTypes';
-import NewFeaturePopup from '../_sharedcomponents/HomescreenWelcome/NewFeaturePopup';
-import { announcement } from '@/app/_constants/mockData';
 import UndoTutorialPopup from '@/app/_components/_sharedcomponents/HomePagePlayMode/UndoTutorialPopup';
+import TimerTutorialPopup from '@/app/_components/_sharedcomponents/HomePagePlayMode/TimerTutorialPopup';
 import { useDeckErrors } from '@/app/_hooks/useDeckErrors';
 import { ErrorModal } from '../_sharedcomponents/Error/ErrorModal';
 
@@ -37,15 +36,15 @@ const HomePagePlayMode: React.FC = () => {
     const [testGameList, setTestGameList] = React.useState([]);
     const [showWelcomePopup, setShowWelcomePopup] = useState(false);
     const [showUpdatePopup, setShowUpdatePopup] = useState(false);
-    const [showNewFeaturePopup, setShowNewFeaturePopup] = useState(false);
     const [showUsernameMustChangePopup, setUsernameMustChangePopup] = useState<boolean>(false);
     const [showUsernameRestrictedPopup, setShowUsernameRestrictedPopup] = useState<boolean>(false);
     const [showReportingDisabledPopup, setShowReportingDisabledPopup] = useState<boolean>(false);
     const [showMutedPopup, setShowMutedPopup] = useState<boolean>(false);
     const [showUndoTutorialPopup, setShowUndoTutorialPopup] = useState<boolean>(false);
+    const [showTimerTutorialPopup, setShowTimerTutorialPopup] = useState<boolean>(false);
     const [pendingFormSubmission, setPendingFormSubmission] = useState<(() => void) | null>(null);
     const [moderationDays, setModerationDays] = useState<number | undefined>(undefined);
-    const { user, updateWelcomeMessage, updateModerationSeenStatus, updateUndoPopupSeenDate, updateMustRequestUsernameChangeSeen, updateReportingDisabledSeen } = useUser();
+    const { user, updateWelcomeMessage, updateModerationSeenStatus, updateUndoPopupSeenDate, updateTimerPopupSeenDate, updateMustRequestUsernameChangeSeen, updateReportingDisabledSeen } = useUser();
 
     // Use shared deck management hook
     const {
@@ -90,30 +89,30 @@ const HomePagePlayMode: React.FC = () => {
         updateWelcomeMessage();
     }
 
-    const closeNewFeaturePopup = () => {
-        setShowNewFeaturePopup(false);
-        markAnnouncementAsSeen(announcement)
-    }
-
     const showTestGames = process.env.NODE_ENV === 'development' && (user?.id === 'exe66' || user?.id === 'th3w4y');
     const showQuickMatch = process.env.NEXT_PUBLIC_DISABLE_LOCAL_QUICK_MATCH !== 'true';
 
-    // Undo Tutorial Popup handlers
+    // Tutorial popup handlers (undo + timer chained)
+    const tutorialDevGateOpen =
+        process.env.NODE_ENV !== 'development' ||
+        process.env.NEXT_PUBLIC_SHOW_LOCAL_ANNOUNCEMENTS === 'true';
+
     const handleFormSubmissionWithUndoCheck = useCallback((originalSubmissionFn: () => void) => {
-        // Check if user has seen the undo popup (works for both signed-in and anonymous users)
-        if (!hasUserSeenUndoPopup(user) && (process.env.NODE_ENV !== 'development' || process.env.NEXT_PUBLIC_SHOW_LOCAL_ANNOUNCEMENTS === 'true')) {
-            // User hasn't seen the popup, show it and store the submission function
+        if (!hasUserSeenUndoPopup(user) && tutorialDevGateOpen) {
             setPendingFormSubmission(() => originalSubmissionFn);
             setShowUndoTutorialPopup(true);
+        } else if (!hasUserSeenTimerPopup(user) && tutorialDevGateOpen) {
+            setPendingFormSubmission(() => originalSubmissionFn);
+            setShowTimerTutorialPopup(true);
         } else {
-            // User has seen the popup, proceed with normal submission
+            // User has seen all tutorials, proceed with normal submission
             originalSubmissionFn();
         }
-    }, [user]);
+    }, [user, tutorialDevGateOpen]);
 
     const handleUndoTutorialClose = useCallback(async () => {
         setShowUndoTutorialPopup(false);
-        
+
         // Mark the popup as seen (handles both signed-in and anonymous users)
         try {
             await markUndoPopupAsSeen(user, updateUndoPopupSeenDate);
@@ -121,12 +120,35 @@ const HomePagePlayMode: React.FC = () => {
             console.error('Failed to mark undo popup as seen:', error);
         }
 
+        // If the timer tutorial also needs to be shown, chain into it instead of submitting.
+        if (!hasUserSeenTimerPopup(user) && tutorialDevGateOpen) {
+            setShowTimerTutorialPopup(true);
+            return;
+        }
+
+        // Otherwise execute the pending form submission
+        if (pendingFormSubmission) {
+            pendingFormSubmission();
+            setPendingFormSubmission(null);
+        }
+    }, [user, pendingFormSubmission, updateUndoPopupSeenDate, tutorialDevGateOpen]);
+
+    const handleTimerTutorialClose = useCallback(async () => {
+        setShowTimerTutorialPopup(false);
+
+        // Mark the popup as seen (handles both signed-in and anonymous users)
+        try {
+            await markTimerPopupAsSeen(user, updateTimerPopupSeenDate);
+        } catch (error) {
+            console.error('Failed to mark timer popup as seen:', error);
+        }
+
         // Execute the pending form submission
         if (pendingFormSubmission) {
             pendingFormSubmission();
             setPendingFormSubmission(null);
         }
-    }, [user, pendingFormSubmission, updateUndoPopupSeenDate]);
+    }, [user, pendingFormSubmission, updateTimerPopupSeenDate]);
 
     const handleChange = (event: React.SyntheticEvent, newValue: number) => {
         setValue(newValue);
@@ -195,7 +217,6 @@ const HomePagePlayMode: React.FC = () => {
         if(user) {
             if (user.showWelcomeMessage && !showUpdatePopup) {
                 setShowMutedPopup(false);
-                setShowNewFeaturePopup(false);
                 setShowWelcomePopup(true);
             }
             setUsernameMustChangePopup(!!user.needsUsernameChange);
@@ -208,7 +229,6 @@ const HomePagePlayMode: React.FC = () => {
             if(user.moderation){
                 setModerationDays(user.moderation.daysRemaining);
                 if(!user.moderation.hasSeen && (!user.showWelcomeMessage && !user.needsUsernameChange)) {
-                    setShowNewFeaturePopup(false);
                     setShowMutedPopup(true);
                 }
                 // check if moderation object still exists
@@ -216,9 +236,6 @@ const HomePagePlayMode: React.FC = () => {
             } else {
                 setShowMutedPopup(false);
             }
-        }
-        if (shouldShowAnnouncement(announcement) && (!user || (!user.showWelcomeMessage && (!user.moderation || (user.moderation.hasSeen))))) {
-            setShowNewFeaturePopup(true);
         }
 
 
@@ -353,12 +370,12 @@ const HomePagePlayMode: React.FC = () => {
             </Card>
             <WelcomePopup open={showWelcomePopup} onClose={closeWelcomePopup} />
             <UpdatePopup open={showUpdatePopup} onClose={closeUpdatePopup} />
-            <NewFeaturePopup open={showNewFeaturePopup} onClose={closeNewFeaturePopup} />
             <UsernameChangeRequiredPopup open={showUsernameMustChangePopup}/>
             <UsernameChangeRestrictedPopup open={showUsernameRestrictedPopup} onClose={handleCloseUsernameRestrictedPopup} />
             <ReportingDisabledPopup open={showReportingDisabledPopup} onClose={handleCloseReportingDisabledPopup} />
             <UserMutedPopup durationDays={moderationDays!} open={showMutedPopup} onClose={handleCloseMutedPopup}></UserMutedPopup>
             <UndoTutorialPopup open={showUndoTutorialPopup} onClose={handleUndoTutorialClose} />
+            <TimerTutorialPopup open={showTimerTutorialPopup} onClose={handleTimerTutorialClose} />
         </>
     );
 };

--- a/src/app/_components/_sharedcomponents/HomePagePlayMode/TimerTutorialPopup.tsx
+++ b/src/app/_components/_sharedcomponents/HomePagePlayMode/TimerTutorialPopup.tsx
@@ -1,0 +1,89 @@
+'use client';
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import Image from 'next/image';
+import TutorialPopup from '@/app/_components/_sharedcomponents/HomePagePlayMode/TutorialPopup';
+
+interface ITimerTutorialPopupProps {
+    open: boolean;
+    onClose: () => void;
+}
+
+const TimerTutorialPopup: React.FC<ITimerTutorialPopupProps> = ({ open, onClose }) => {
+    const styles = {
+        body: {
+            color: '#B4DCEB',
+            fontSize: '0.95rem',
+            lineHeight: 1.5,
+        },
+        emphasized: {
+            color: '#fff',
+            fontWeight: 'bold',
+        },
+        paragraph: {
+            color: '#B4DCEB',
+            fontSize: '0.95rem',
+            lineHeight: 1.5,
+            marginBottom: '12px',
+        },
+        bulletList: {
+            color: '#B4DCEB',
+            fontSize: '0.95rem',
+            lineHeight: 1.5,
+            pl: '20px',
+            mb: '12px',
+            '& li::marker': { color: '#B4DCEB' },
+        },
+        imageWrapper: {
+            mt: '16px',
+            display: 'flex',
+            justifyContent: 'center',
+        },
+        imageContainer: {
+            position: 'relative',
+            width: 'clamp(240px, 60vw, 480px)',
+            height: 'clamp(135px, 34vw, 270px)',
+            borderRadius: '8px',
+            overflow: 'hidden',
+        },
+        discordLink: {
+            color: 'lightblue',
+        },
+    } as const;
+
+    return (
+        <TutorialPopup
+            open={open}
+            onClose={onClose}
+            titleId="timer-tutorial-dialog-title"
+            title="Game Timer Rules"
+        >
+            <Box sx={styles.body}>
+                <Typography component="p" sx={styles.paragraph}>
+                    Each player has <Box component="span" sx={styles.emphasized}>20 seconds per action</Box> backed
+                    by a <Box component="span" sx={styles.emphasized}>2 minute time bank</Box>. When a player&apos;s
+                    20 seconds runs out, their timer begins drawing from their bank. The bank does not refill — if a
+                    player&apos;s bank runs out, that player concedes the game.
+                </Typography>
+
+                <Typography component="p" sx={styles.paragraph}>
+                    Note that this only applies to <Box component="span" sx={styles.emphasized}>public games</Box>.
+                    Private games do not have a timer.
+                </Typography>
+            </Box>
+
+            <Box sx={styles.imageWrapper}>
+                <Box sx={styles.imageContainer}>
+                    <Image
+                        src="/timerexplainer.png"
+                        alt="Updated Game Timers"
+                        fill
+                        style={{ objectFit: 'contain' }}
+                    />
+                </Box>
+            </Box>
+        </TutorialPopup>
+    );
+};
+
+export default TimerTutorialPopup;

--- a/src/app/_components/_sharedcomponents/HomePagePlayMode/TutorialPopup.tsx
+++ b/src/app/_components/_sharedcomponents/HomePagePlayMode/TutorialPopup.tsx
@@ -1,0 +1,70 @@
+'use client';
+import React from 'react';
+import {
+    Typography,
+    Dialog,
+    DialogContent,
+    DialogActions,
+} from '@mui/material';
+import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
+
+interface ITutorialPopupProps {
+    open: boolean;
+    onClose: () => void;
+    title: React.ReactNode;
+    titleId: string;
+    children: React.ReactNode;
+}
+
+const TutorialPopup: React.FC<ITutorialPopupProps> = ({ open, onClose, title, titleId, children }) => {
+    const styles = {
+        dialog: {
+            '& .MuiDialog-paper': {
+                backgroundColor: '#1E2D32',
+                borderRadius: '20px',
+                maxWidth: '720px',
+                width: '100%',
+                padding: '20px',
+                border: '2px solid transparent',
+                background:
+                    'linear-gradient(#0F1F27, #030C13) padding-box, linear-gradient(to top, #30434B, #50717D) border-box',
+            },
+        },
+        title: {
+            color: '#018DC1',
+            fontSize: '2rem',
+            textAlign: 'left',
+            marginBottom: '16px',
+        },
+        actions: {
+            justifyContent: 'center',
+            padding: '16px 0',
+            gap: '16px',
+        },
+    } as const;
+
+    return (
+        <Dialog
+            open={open}
+            onClose={(event, reason) => {
+                if (reason === 'backdropClick') return; // disable backdrop closing
+                onClose();
+            }}
+            disableEscapeKeyDown
+            aria-labelledby={titleId}
+            sx={styles.dialog}
+        >
+            <DialogContent>
+                <Typography variant="h4" sx={styles.title} id={titleId}>
+                    {title}
+                </Typography>
+                {children}
+            </DialogContent>
+            <DialogActions sx={styles.actions}>
+                <PreferenceButton buttonFnc={onClose} text="Got it" variant="standard" />
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default TutorialPopup;

--- a/src/app/_components/_sharedcomponents/HomePagePlayMode/UndoTutorialPopup.tsx
+++ b/src/app/_components/_sharedcomponents/HomePagePlayMode/UndoTutorialPopup.tsx
@@ -3,13 +3,9 @@ import React from 'react';
 import {
     Box,
     Typography,
-    Dialog,
-    DialogContent,
-    DialogActions,
 } from '@mui/material';
 import Image from 'next/image';
-import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
-import { announcement } from '@/app/_constants/mockData';
+import TutorialPopup from '@/app/_components/_sharedcomponents/HomePagePlayMode/TutorialPopup';
 
 interface IUndoTutorialPopupProps {
     open: boolean;
@@ -18,30 +14,6 @@ interface IUndoTutorialPopupProps {
 
 const UndoTutorialPopup: React.FC<IUndoTutorialPopupProps> = ({ open, onClose }) => {
     const styles = {
-        dialog: {
-            '& .MuiDialog-paper': {
-                backgroundColor: '#1E2D32',
-                borderRadius: '20px',
-                maxWidth: '720px',
-                width: '100%',
-                padding: '20px',
-                border: '2px solid transparent',
-                background:
-                    'linear-gradient(#0F1F27, #030C13) padding-box, linear-gradient(to top, #30434B, #50717D) border-box',
-            },
-        },
-        title: {
-            color: '#018DC1',
-            fontSize: '2rem',
-            textAlign: 'left',
-            marginBottom: '16px',
-        },
-        subtitle: {
-            fontSize: '1.2rem',
-            color: '#fff',
-            marginTop: '0.5rem',
-            marginBottom: '0.5rem',
-        },
         whatsNewList: {
             pl: '16px',
             mt: '4px',
@@ -67,17 +39,6 @@ const UndoTutorialPopup: React.FC<IUndoTutorialPopupProps> = ({ open, onClose })
             borderRadius: '8px',
             overflow: 'hidden',
         },
-        actions: {
-            justifyContent: 'center',
-            padding: '16px 0',
-            gap: '16px',
-        },
-        closeButton: {
-            backgroundColor: '#2F7DB6',
-            color: '#fff',
-            '&:hover': { backgroundColor: '#3590D2' },
-            minWidth: '120px',
-        },
         infoItem: {
             color: '#B8860B',
             fontSize: '0.85rem',
@@ -86,81 +47,68 @@ const UndoTutorialPopup: React.FC<IUndoTutorialPopupProps> = ({ open, onClose })
     } as const;
 
     return (
-        <Dialog
+        <TutorialPopup
             open={open}
-            onClose={(event, reason) => {
-                if (reason === 'backdropClick') return; // disable backdrop closing
-                onClose();
-            }}
-            disableEscapeKeyDown
-            aria-labelledby="whats-new-dialog-title"
-            sx={styles.dialog}
+            onClose={onClose}
+            titleId="undo-tutorial-dialog-title"
+            title={<>✨ Undo in Public Games</>}
         >
-            <DialogContent>
-                <Typography variant="h4" sx={styles.title} id="whats-new-dialog-title">
-                    ✨ Undo in Public Games
+            <Box component="ul" sx={styles.whatsNewList}>
+                <Typography component="span" variant="body2" sx={styles.whatsNewItem}>
+                    Undo in public games (queue and public lobbies) has special rules to prevent abuse.
                 </Typography>
+                <br/>
+                <br/>
 
-                <Box component="ul" sx={styles.whatsNewList}>
-                    <Typography component="span" variant="body2" sx={styles.whatsNewItem}>
-                        Undo in public games (queue and public lobbies) has special rules to prevent abuse.
+                <li>
+                    <Typography component="span" variant="body2" sx={styles.infoItem}>
+                        You receive <strong>one &quot;free&quot; undo per game</strong>. After it is used, every undo will <strong>send a request to the opponent 
+                            for approval</strong>. They can allow or deny the request.
                     </Typography>
-                    <br/>
-                    <br/>
+                </li>
+                <br/>
 
-                    <li>
-                        <Typography component="span" variant="body2" sx={styles.infoItem}>
-                            You receive <strong>one &quot;free&quot; undo per game</strong>. After it is used, every undo will <strong>send a request to the opponent 
-                                for approval</strong>. They can allow or deny the request.
-                        </Typography>
-                    </li>
-                    <br/>
+                <li>
+                    <Typography component="span" variant="body2" sx={styles.infoItem}>
+                        Undo in certain game situations, <strong>such as after drawing or revealing cards</strong>, will <strong>always </strong>
+                        require opponent approval (even if you have a free undo available).
+                    </Typography>
+                </li>
+                <br/>
 
-                    <li>
-                        <Typography component="span" variant="body2" sx={styles.infoItem}>
-                            Undo in certain game situations, <strong>such as after drawing or revealing cards</strong>, will <strong>always </strong>
-                            require opponent approval (even if you have a free undo available).
-                        </Typography>
-                    </li>
-                    <br/>
-
-                    <li>
-                        <Typography component="span" variant="body2" sx={styles.infoItem}>
-                            If enough undo requests are rejected, a player will have the option to <strong>block any further undo requests in that game</strong>.
-                        </Typography>
-                    </li>
+                <li>
+                    <Typography component="span" variant="body2" sx={styles.infoItem}>
+                        If enough undo requests are rejected, a player will have the option to <strong>block any further undo requests in that game</strong>.
+                    </Typography>
+                </li>
+            </Box>
+            <Box sx={styles.screenshotWrapper}>
+                <Box sx={styles.imageContainer}>
+                    <Image
+                        src="/undo-button.png"
+                        alt="Undo Button"
+                        fill
+                        style={{ objectFit: 'contain' }}
+                    />
                 </Box>
-                <Box sx={styles.screenshotWrapper}>
-                    <Box sx={styles.imageContainer}>
-                        <Image
-                            src="/undo-button.png"
-                            alt="Undo Button"
-                            fill
-                            style={{ objectFit: 'contain' }}
-                        />
-                    </Box>
-                    <Box sx={styles.imageContainer}>
-                        <Image
-                            src="/request-undo.png"
-                            alt="Request Undo Button"
-                            fill
-                            style={{ objectFit: 'contain' }}
-                        />
-                    </Box>
-                    <Box sx={styles.imageContainer}>
-                        <Image
-                            src="/blocked-undo.png"
-                            alt="Blocked Undo Button"
-                            fill
-                            style={{ objectFit: 'contain' }}
-                        />
-                    </Box>
+                <Box sx={styles.imageContainer}>
+                    <Image
+                        src="/request-undo.png"
+                        alt="Request Undo Button"
+                        fill
+                        style={{ objectFit: 'contain' }}
+                    />
                 </Box>
-            </DialogContent>
-            <DialogActions sx={styles.actions}>
-                <PreferenceButton buttonFnc={onClose} text="Got it" variant="standard" />
-            </DialogActions>
-        </Dialog>
+                <Box sx={styles.imageContainer}>
+                    <Image
+                        src="/blocked-undo.png"
+                        alt="Blocked Undo Button"
+                        fill
+                        style={{ objectFit: 'contain' }}
+                    />
+                </Box>
+            </Box>
+        </TutorialPopup>
     );
 };
 

--- a/src/app/_constants/mockData.ts
+++ b/src/app/_constants/mockData.ts
@@ -111,6 +111,6 @@ export const announcement: IAnnouncement = {
     - We'll be actively monitoring the values for both the per-action timer and the time bank, and may adjust them based on how games play out.<br/>
     <br/>
     Have feedback? Let us know in our <a target="_blank" href="https://discord.gg/hKRaqHND4v" style="color:lightblue;">Discord</a>!`,
-    endDate: '2027-05-06', // The date should be year-month-day
+    endDate: '2026-05-24', // The date should be year-month-day
     image:'/timerexplainer.png'
 }

--- a/src/app/_contexts/User.context.tsx
+++ b/src/app/_contexts/User.context.tsx
@@ -28,7 +28,8 @@ const UserContext = createContext<IUserContextType>({
     updateReportingDisabledSeen: () => {},
     updateUserPreferences: () => {},
     updateModerationSeenStatus: () => {},
-    updateUndoPopupSeenDate: () => {}
+    updateUndoPopupSeenDate: () => {},
+    updateTimerPopupSeenDate: () => {}
 });
 
 export const UserProvider: React.FC<{ children: ReactNode }> = ({
@@ -74,6 +75,7 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({
                         reportingDisabled: serverUser.reportingDisabled,
                         moderation: serverUser.moderation,
                         undoPopupSeenDate: serverUser.undoPopupSeenDate,
+                        timerPopupSeenDate: serverUser.timerPopupSeenDate,
                     });
                     await update({ userId: serverUser.id });
                     // Fetch mod status
@@ -180,6 +182,16 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({
         })
     }
 
+    const updateTimerPopupSeenDate = () => {
+        setUser((prevUser) => {
+            if(!prevUser) return null;
+            return {
+                ...prevUser,
+                timerPopupSeenDate: new Date()
+            }
+        })
+    }
+
     const updateNeedsUsernameChange = () => {
         setUser((prevUser) => {
             if(!prevUser) return null;
@@ -262,6 +274,7 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({
             updateUsername,
             updateWelcomeMessage,
             updateUndoPopupSeenDate,
+            updateTimerPopupSeenDate,
             updateNeedsUsernameChange,
             updateMustRequestUsernameChangeSeen,
             updateReportingDisabledSeen,

--- a/src/app/_contexts/UserTypes.ts
+++ b/src/app/_contexts/UserTypes.ts
@@ -46,6 +46,7 @@ export interface IGetUser {
     reportingDisabled?: ModerationFieldState | null;
     moderation?: IModerationAction | null,
     undoPopupSeenDate?: Date | null
+    timerPopupSeenDate?: Date | null
 }
 
 export interface ISoundPreferences {
@@ -90,6 +91,7 @@ export interface IUserContextType {
     updateUserPreferences: (preferences: IPreferences) => void;
     updateModerationSeenStatus: (moderation: IModerationAction | null) => void;
     updateUndoPopupSeenDate: () => void;
+    updateTimerPopupSeenDate: () => void;
 }
 
 export enum AdminRole {

--- a/src/app/_utils/ServerAndLocalStorageUtils.ts
+++ b/src/app/_utils/ServerAndLocalStorageUtils.ts
@@ -1064,6 +1064,85 @@ export const markUndoPopupAsSeen = async (user: IUser | null, updateCachedLocalS
 };
 
 /**
+ * Saves the timer popup seen date to localStorage for anonymous users
+ * @param date The date string when the popup was seen
+ */
+export const saveTimerPopupSeenToLocalStorage = (date: string): void => {
+    try {
+        localStorage.setItem('timerPopupSeenDate', date);
+    } catch (error) {
+        console.error('Error saving timer popup seen date to localStorage:', error);
+    }
+};
+
+/**
+ * Gets the timer popup seen date from localStorage for anonymous users
+ * @returns The date string when the popup was seen, or null if not seen
+ */
+export const getTimerPopupSeenFromLocalStorage = (): string | null => {
+    try {
+        return localStorage.getItem('timerPopupSeenDate');
+    } catch (error) {
+        console.error('Error getting timer popup seen date from localStorage:', error);
+        return null;
+    }
+};
+
+/**
+ * Checks if the user has seen the timer popup, handling both signed-in and anonymous users
+ * @param user The current user (or null if anonymous)
+ * @returns True if the user has seen the popup, false otherwise
+ */
+export const hasUserSeenTimerPopup = (user: IUser | null): boolean => {
+    if (user) {
+        // Signed-in user: check server data
+        if (!!user.timerPopupSeenDate) {
+            saveTimerPopupSeenToLocalStorage(user.timerPopupSeenDate.toString());
+            return true;
+        }
+
+        return false;
+    } else {
+        // Anonymous user: check localStorage
+        return !!getTimerPopupSeenFromLocalStorage();
+    }
+};
+
+/**
+ * Marks the timer popup as seen, handling both signed-in and anonymous users
+ * @param user The current user (or null if anonymous)
+ * @param updateCachedLocalState Optional callback to update local user context state for signed-in users
+ * @returns Promise that resolves when the operation is complete (for server calls)
+ */
+export const markTimerPopupAsSeen = async (user: IUser | null, updateCachedLocalState: () => void): Promise<void> => {
+    const currentDate = new Date().toISOString();
+
+    if (user) {
+        // Signed-in user: update local state first for immediate UI update
+        if (updateCachedLocalState) {
+            updateCachedLocalState();
+        }
+
+        // Then save to server
+        try {
+            await fetch(`${process.env.NEXT_PUBLIC_ROOT_URL}/api/user/${user.id}/timer-popup-seen`, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                credentials: 'include'
+            });
+        } catch (error) {
+            console.error('Failed to mark timer popup as seen on server:', error);
+            throw error;
+        }
+    }
+
+    // save to local storage for both signed-in and anonymous so that a signed-in user doesn't get a repeat
+    saveTimerPopupSeenToLocalStorage(currentDate);
+};
+
+/**
  * Updates the name of a deck
  * @param deckId The deck ID to update
  * @param newName The new name for the deck


### PR DESCRIPTION
Migrated the timer explanation popup from being an announcement to a dedicated tutorial popup that will happen the first time a user tries to queue or join a lobby. This is already how we handle the undo tutorial, so we're just extending the pattern.

BE PR: https://github.com/SWU-Karabast/forceteki/pull/2431

<img width="826" height="728" alt="image" src="https://github.com/user-attachments/assets/b043d201-1e8f-48c6-a1e8-c5e5ffd7a80d" />
