### PR TITLE
Remove view flipside from leader upgrades

### DIFF
--- a/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
@@ -47,6 +47,7 @@ const GameCard: React.FC<IGameCardProps> = ({
     const hoverTimeout = React.useRef<number | undefined>(undefined);
     const open = Boolean(anchorElement);
     const isHoveredInChat = hoveredChatCard.id === card.uuid;
+    const isPreviewingLeaderCard = anchorElement?.getAttribute('data-card-type') === 'leader';
 
     const {
         aspectRatio,
@@ -58,7 +59,7 @@ const GameCard: React.FC<IGameCardProps> = ({
         setPreviewImage,
         frontCardStyle: CardStyle.Plain,
         backCardStyle: CardStyle.PlainLeader,
-        isLeader: anchorElement?.getAttribute('data-card-type') === 'leader',
+        isLeader: isPreviewingLeaderCard,
         isDeployed: true,
     });
 
@@ -767,7 +768,7 @@ const GameCard: React.FC<IGameCardProps> = ({
                 {...popoverConfig()}
             >
                 <Box sx={{ ...styles.cardPreview, backgroundImage: previewImage }} />
-                {(card.printedType === 'leader') && !isTouchDevice && !isFlipped && (
+                {isPreviewingLeaderCard && !isTouchDevice && !isFlipped && (
                     <Typography variant={'body1'} sx={styles.ctrlText}
                     >CTRL: View Flipside</Typography>
                 )}


### PR DESCRIPTION
Fixes #539

# Fixed UI

<img width="830" height="570" alt="Screenshot 2026-05-25 at 8 54 32 PM" src="https://github.com/user-attachments/assets/ba15d0c2-f877-4c51-a3b5-82267358e1fb" />
<img width="819" height="580" alt="Screenshot 2026-05-25 at 8 54 37 PM" src="https://github.com/user-attachments/assets/7e745e9c-a199-4ad5-9c8b-6fa861e8e993" />
<img width="1019" height="492" alt="Screenshot 2026-05-25 at 8 55 40 PM" src="https://github.com/user-attachments/assets/3deb3edf-d771-40ff-8c26-d13088b5aca9" />
