### PR TITLE
Migrate to MUI 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
 				"@aws-sdk/s3-request-presigner": "^3.917.0",
 				"@emotion/react": "^11.13.5",
 				"@emotion/styled": "^11.13.5",
-				"@mui/icons-material": "^6.1.8",
-				"@mui/material": "^6.1.8",
+				"@mui/icons-material": "^7.3.11",
+				"@mui/material": "^7.3.11",
 				"@svgr/webpack": "^8.1.0",
 				"html-react-parser": "^5.1.18",
 				"jsonwebtoken": "^9.0.2",
@@ -24,6 +24,7 @@
 				"react": "^18",
 				"react-dom": "^18",
 				"react-icons": "^5.3.0",
+				"react-is": "^18.3.1",
 				"simplebar-react": "^3.3.1",
 				"socket.io-client": "^4.8.1",
 				"uuid": "^11.0.5"
@@ -2799,12 +2800,10 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-			"integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -2874,9 +2873,9 @@
 			}
 		},
 		"node_modules/@emotion/cache": {
-			"version": "11.13.5",
-			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.13.5.tgz",
-			"integrity": "sha512-Z3xbtJ+UcK76eWkagZ1onvn/wAVb1GOMuR15s30Fm2wrMgC7jzpnO2JZXr4eujTTqoQFUrZIw/rT0c6Zzjca1g==",
+			"version": "11.14.0",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+			"integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
 			"license": "MIT",
 			"dependencies": {
 				"@emotion/memoize": "^0.9.0",
@@ -3210,9 +3209,9 @@
 			}
 		},
 		"node_modules/@mui/core-downloads-tracker": {
-			"version": "6.1.8",
-			"resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.1.8.tgz",
-			"integrity": "sha512-TGAvzwUg9hybDacwfIGFjI2bXYXrIqky+vMfaeay8rvT56/PNAlvIDUJ54kpT5KRc9AWAihOvtDI7/LJOThOmQ==",
+			"version": "7.3.11",
+			"resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.11.tgz",
+			"integrity": "sha512-a7I/b/nBTdXYz2cOSlEmkQ9WWE1x8FHpqMhFPp+Y1VPFxcOw91G5ELOHARQAGSPy5V+UCgJua6K/1x70bAtQPw==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -3220,12 +3219,12 @@
 			}
 		},
 		"node_modules/@mui/icons-material": {
-			"version": "6.1.8",
-			"resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.1.8.tgz",
-			"integrity": "sha512-6frsXcf1TcJKWevWwRup6V4L8lzI33cbHcAjT83YLgKw0vYRZKY0kjMI9fhrJZdRWXgFFgKKvEv3GjoxbqFF7A==",
+			"version": "7.3.11",
+			"resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.11.tgz",
+			"integrity": "sha512-+hz5ilwHZ3djd5es3sCErLioqe/NhZcYTsV/TNXZAMdJdb23F4xzJjqnnZdnurc3S1+ietcssRNqieOhPQLZ7Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.26.0"
+				"@babel/runtime": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -3235,7 +3234,7 @@
 				"url": "https://opencollective.com/mui-org"
 			},
 			"peerDependencies": {
-				"@mui/material": "^6.1.8",
+				"@mui/material": "^7.3.11",
 				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
 				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			},
@@ -3246,22 +3245,22 @@
 			}
 		},
 		"node_modules/@mui/material": {
-			"version": "6.1.8",
-			"resolved": "https://registry.npmjs.org/@mui/material/-/material-6.1.8.tgz",
-			"integrity": "sha512-QZdQFnXct+7NXIzHgT3qt+sQiO7HYGZU2vymP9Xl9tUMXEOA/S1mZMMb7+WGZrk5TzNlU/kP/85K0da5V1jXoQ==",
+			"version": "7.3.11",
+			"resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.11.tgz",
+			"integrity": "sha512-yq8bPc3LxOwKRWpcjRgDkYFmpM6aKlARfESTmOQcvLYFeJwtHte2tw6hJDrb8sk8wcvpDprHEHVaoUU0MslIkw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.26.0",
-				"@mui/core-downloads-tracker": "^6.1.8",
-				"@mui/system": "^6.1.8",
-				"@mui/types": "^7.2.19",
-				"@mui/utils": "^6.1.8",
+				"@babel/runtime": "^7.28.6",
+				"@mui/core-downloads-tracker": "^7.3.11",
+				"@mui/system": "^7.3.11",
+				"@mui/types": "^7.4.12",
+				"@mui/utils": "^7.3.11",
 				"@popperjs/core": "^2.11.8",
-				"@types/react-transition-group": "^4.4.11",
+				"@types/react-transition-group": "^4.4.12",
 				"clsx": "^2.1.1",
-				"csstype": "^3.1.3",
+				"csstype": "^3.2.3",
 				"prop-types": "^15.8.1",
-				"react-is": "^18.3.1",
+				"react-is": "^19.2.3",
 				"react-transition-group": "^4.4.5"
 			},
 			"engines": {
@@ -3274,7 +3273,7 @@
 			"peerDependencies": {
 				"@emotion/react": "^11.5.0",
 				"@emotion/styled": "^11.3.0",
-				"@mui/material-pigment-css": "^6.1.8",
+				"@mui/material-pigment-css": "^7.3.11",
 				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
 				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -3295,13 +3294,13 @@
 			}
 		},
 		"node_modules/@mui/private-theming": {
-			"version": "6.1.8",
-			"resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.1.8.tgz",
-			"integrity": "sha512-TuKl7msynCNCVvhX3c0ef1sF0Qb3VHcPs8XOGB/8bdOGBr/ynmIG1yTMjZeiFQXk8yN9fzK/FDEKMFxILNn3wg==",
+			"version": "7.3.11",
+			"resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.11.tgz",
+			"integrity": "sha512-9B+YKms0fRHbNrqp9tOT/DNbNnU5gyvJ1o3qAGXfq8GmZcbJnE3At9x07Zr/o0pkhzg4aDdwXVqe4+AcgtOCPA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.26.0",
-				"@mui/utils": "^6.1.8",
+				"@babel/runtime": "^7.28.6",
+				"@mui/utils": "^7.3.11",
 				"prop-types": "^15.8.1"
 			},
 			"engines": {
@@ -3322,16 +3321,16 @@
 			}
 		},
 		"node_modules/@mui/styled-engine": {
-			"version": "6.1.8",
-			"resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.1.8.tgz",
-			"integrity": "sha512-ZvEoT0U2nPLSLI+B4by4cVjaZnPT2f20f4JUPkyHdwLv65ZzuoHiTlwyhqX1Ch63p8bcJzKTHQVGisEoMK6PGA==",
+			"version": "7.3.10",
+			"resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.10.tgz",
+			"integrity": "sha512-WxE9SiF8xskAQqGjsp0poXCkCqsoXFEsSr0HBXfApmGHR+DBnXRp+z46Vsltg4gpPM4Z96DeAQRpeAOnhNg7Ng==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.26.0",
-				"@emotion/cache": "^11.13.1",
-				"@emotion/serialize": "^1.3.2",
+				"@babel/runtime": "^7.28.6",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
 				"@emotion/sheet": "^1.4.0",
-				"csstype": "^3.1.3",
+				"csstype": "^3.2.3",
 				"prop-types": "^15.8.1"
 			},
 			"engines": {
@@ -3356,18 +3355,18 @@
 			}
 		},
 		"node_modules/@mui/system": {
-			"version": "6.1.8",
-			"resolved": "https://registry.npmjs.org/@mui/system/-/system-6.1.8.tgz",
-			"integrity": "sha512-i1kLfQoWxzFpXTBQIuPoA3xKnAnP3en4I2T8xIolovSolGQX5k8vGjw1JaydQS40td++cFsgCdEU458HDNTGUA==",
+			"version": "7.3.11",
+			"resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.11.tgz",
+			"integrity": "sha512-7izwGWdNawAKpBKcRlx7f2gFnAAjmASBWvMcyX4YYEeLOFsbfGRbUYGInvnAcUeql3rPxI7F9Ft4oY2OLRz44g==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.26.0",
-				"@mui/private-theming": "^6.1.8",
-				"@mui/styled-engine": "^6.1.8",
-				"@mui/types": "^7.2.19",
-				"@mui/utils": "^6.1.8",
+				"@babel/runtime": "^7.28.6",
+				"@mui/private-theming": "^7.3.11",
+				"@mui/styled-engine": "^7.3.10",
+				"@mui/types": "^7.4.12",
+				"@mui/utils": "^7.3.11",
 				"clsx": "^2.1.1",
-				"csstype": "^3.1.3",
+				"csstype": "^3.2.3",
 				"prop-types": "^15.8.1"
 			},
 			"engines": {
@@ -3396,10 +3395,13 @@
 			}
 		},
 		"node_modules/@mui/types": {
-			"version": "7.2.19",
-			"resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.19.tgz",
-			"integrity": "sha512-6XpZEM/Q3epK9RN8ENoXuygnqUQxE+siN/6rGRi2iwJPgBUR25mphYQ9ZI87plGh58YoZ5pp40bFvKYOCDJ3tA==",
+			"version": "7.4.12",
+			"resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
+			"integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
 			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.28.6"
+			},
 			"peerDependencies": {
 				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			},
@@ -3410,17 +3412,17 @@
 			}
 		},
 		"node_modules/@mui/utils": {
-			"version": "6.1.8",
-			"resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.1.8.tgz",
-			"integrity": "sha512-O2DWb1kz8hiANVcR7Z4gOB3SvPPsSQGUmStpyBDzde6dJIfBzgV9PbEQOBZd3EBsd1pB+Uv1z5LAJAbymmawrA==",
+			"version": "7.3.11",
+			"resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.11.tgz",
+			"integrity": "sha512-XTjGnifwteg71/ij+0e7Y7d+hwyntMYP5wPoA/g2drdGH+Flkvjwy0OfrVpKBbaOvofq4zU/LIyUZyKgmWu18g==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.26.0",
-				"@mui/types": "^7.2.19",
-				"@types/prop-types": "^15.7.13",
+				"@babel/runtime": "^7.28.6",
+				"@mui/types": "^7.4.12",
+				"@types/prop-types": "^15.7.15",
 				"clsx": "^2.1.1",
 				"prop-types": "^15.8.1",
-				"react-is": "^18.3.1"
+				"react-is": "^19.2.3"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -4862,9 +4864,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/prop-types": {
-			"version": "15.7.13",
-			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
-			"integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
+			"version": "15.7.15",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
@@ -4888,11 +4890,11 @@
 			}
 		},
 		"node_modules/@types/react-transition-group": {
-			"version": "4.4.11",
-			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.11.tgz",
-			"integrity": "sha512-RM05tAniPZ5DZPzzNFP+DmrcOdD0efDUxMy3145oljWSl3x9ZV5vhme98gTxFrj2lhXvmGNnUiuDyJgY9IKkNA==",
+			"version": "4.4.12",
+			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+			"integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
 			"license": "MIT",
-			"dependencies": {
+			"peerDependencies": {
 				"@types/react": "*"
 			}
 		},
@@ -5850,9 +5852,9 @@
 			"license": "CC0-1.0"
 		},
 		"node_modules/csstype": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
 			"license": "MIT"
 		},
 		"node_modules/damerau-levenshtein": {
@@ -7294,12 +7296,6 @@
 			"dependencies": {
 				"react-is": "^16.7.0"
 			}
-		},
-		"node_modules/hoist-non-react-statics/node_modules/react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"license": "MIT"
 		},
 		"node_modules/html-dom-parser": {
 			"version": "5.0.10",
@@ -8808,12 +8804,6 @@
 				"react-is": "^16.13.1"
 			}
 		},
-		"node_modules/prop-types/node_modules/react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"license": "MIT"
-		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8945,12 +8935,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/regenerator-runtime": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-			"license": "MIT"
 		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
 		"@aws-sdk/s3-request-presigner": "^3.917.0",
 		"@emotion/react": "^11.13.5",
 		"@emotion/styled": "^11.13.5",
-		"@mui/icons-material": "^6.1.8",
-		"@mui/material": "^6.1.8",
+		"@mui/icons-material": "^7.3.11",
+		"@mui/material": "^7.3.11",
 		"@svgr/webpack": "^8.1.0",
 		"html-react-parser": "^5.1.18",
 		"jsonwebtoken": "^9.0.2",
@@ -27,6 +27,7 @@
 		"react": "^18",
 		"react-dom": "^18",
 		"react-icons": "^5.3.0",
+		"react-is": "^18.3.1",
 		"simplebar-react": "^3.3.1",
 		"socket.io-client": "^4.8.1",
 		"uuid": "^11.0.5"
@@ -41,5 +42,8 @@
 		"eslint-config-next": "14.2.14",
 		"eslint-plugin-next": "^0.0.0",
 		"typescript": "^5"
+	},
+	"overrides": {
+		"react-is": "^18.3.1"
 	}
 }

--- a/src/app/DeckPage/[DeckId]/page.tsx
+++ b/src/app/DeckPage/[DeckId]/page.tsx
@@ -11,7 +11,7 @@ import {
     Typography,
     useMediaQuery
 } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import DeckComponent from '@/app/_components/DeckPage/DeckComponent/DeckComponent';
 import { useParams, useRouter } from 'next/navigation';
 import { fetchDeckData, IDeckData } from '@/app/_utils/fetchDeckData';

--- a/src/app/DeckPage/layout.tsx
+++ b/src/app/DeckPage/layout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Box, Typography } from '@mui/material';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import { s3ImageURL } from '@/app/_utils/s3Utils';
 
 export default function DeckLayout({

--- a/src/app/DeckPage/page.tsx
+++ b/src/app/DeckPage/page.tsx
@@ -2,7 +2,7 @@
 import { Box, MenuItem, Typography } from '@mui/material';
 import React, { ChangeEvent, useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation'
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import StyledTextField from '@/app/_components/_sharedcomponents/_styledcomponents/StyledTextField';
 import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
 import { determineDeckSource, IDeckData } from '@/app/_utils/fetchDeckData';

--- a/src/app/GameBoard/page.tsx
+++ b/src/app/GameBoard/page.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 'use client';
 import React, { useState, useEffect } from 'react';
-import { Box, Grid2 as Grid, Typography } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 import ChatDrawer from '../_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer';
 import OpponentCardTray from '../_components/Gameboard/OpponentCardTray/OpponentCardTray';
 import Board from '../_components/Gameboard/Board/Board';

--- a/src/app/Navigation/NavBar.tsx
+++ b/src/app/Navigation/NavBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { usePathname, useRouter } from 'next/navigation';
-import { Typography, Grid2 as Grid } from '@mui/material';
+import { Typography, Grid } from '@mui/material';
 import ControlHub from '../_components/_sharedcomponents/ControlHub/ControlHub';
 import { useUser } from '../_contexts/User.context';
 import React from 'react';

--- a/src/app/Unimplemented/layout.tsx
+++ b/src/app/Unimplemented/layout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Box, Typography } from '@mui/material';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import { s3ImageURL } from '@/app/_utils/s3Utils';
 
 

--- a/src/app/_components/Gameboard/Board/Board.tsx
+++ b/src/app/_components/Gameboard/Board/Board.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typography, Box, Grid2 as Grid } from '@mui/material';
+import { Typography, Box } from '@mui/material';
 import { debugBorder } from '@/app/_utils/debug';
 import UnitsBoard from '../_subcomponents/UnitsBoard';
 import { IBoardProps } from '@/app/_components/Gameboard/GameboardTypes';

--- a/src/app/_components/Gameboard/OpponentCardTray/OpponentCardTray.tsx
+++ b/src/app/_components/Gameboard/OpponentCardTray/OpponentCardTray.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CloseOutlined, SettingsOutlined } from '@mui/icons-material';
-import { Box, Grid2 as Grid, Popover, PopoverOrigin } from '@mui/material';
+import { Box, Grid, Popover, PopoverOrigin } from '@mui/material';
 import Resources from '../_subcomponents/PlayerTray/Resources';
 import Credits from '../_subcomponents/PlayerTray/Credits';
 import PlayerHand from '../_subcomponents/PlayerTray/PlayerHand';

--- a/src/app/_components/Gameboard/PlayerCardTray/PlayerCardTray.tsx
+++ b/src/app/_components/Gameboard/PlayerCardTray/PlayerCardTray.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Box from '@mui/material/Box';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import { ChatBubbleOutline } from '@mui/icons-material';
 import Resources from '../_subcomponents/PlayerTray/Resources';
 import Credits from '../_subcomponents/PlayerTray/Credits';

--- a/src/app/_components/Gameboard/_subcomponents/PlayerTray/CardActionTray.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/PlayerTray/CardActionTray.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Button, Box } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import { useGame } from '@/app/_contexts/Game.context';
 import { keyframes } from '@mui/system';
 import { debugBorder } from '@/app/_utils/debug';

--- a/src/app/_components/Gameboard/_subcomponents/UnitsBoard.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/UnitsBoard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Grid2 as Grid } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 import { debugBorder, isBreakpointOverlayEnabled } from '@/app/_utils/debug';
 import useScreenOrientation from '@/app/_utils/useScreenOrientation';
 import GameCard from '../../_sharedcomponents/Cards/GameCard';

--- a/src/app/_components/Lobby/Players/Players.tsx
+++ b/src/app/_components/Lobby/Players/Players.tsx
@@ -1,7 +1,7 @@
 // Players.tsx
 import React, { useEffect, useRef } from 'react';
 import { Card, Box, Typography } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import { ILobbyUserProps, IPlayersProps } from '../LobbyTypes';
 import LeaderBaseCard from '@/app/_components/_sharedcomponents/Cards/LeaderBaseCard';
 import { useGame } from '@/app/_contexts/Game.context';

--- a/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Popover, PopoverOrigin, Tooltip, Typography } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import { CardStyle, ICardData, IGameCardProps } from './CardTypes';
 import CardValueAdjuster from './CardValueAdjuster';
 import { useGame } from '@/app/_contexts/Game.context';

--- a/src/app/_components/_sharedcomponents/Preferences/PreferencesSubElementVariants/CosmeticsTab.tsx
+++ b/src/app/_components/_sharedcomponents/Preferences/PreferencesSubElementVariants/CosmeticsTab.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import { useUser } from '@/app/_contexts/User.context';
 import { useEffect, useState } from 'react';
 import { savePreferencesGeneric } from '@/app/_utils/genericPreferenceFunctions';

--- a/src/app/_components/_sharedcomponents/Preferences/PreferencesSubElementVariants/KeyboardShortcutsTab.tsx
+++ b/src/app/_components/_sharedcomponents/Preferences/PreferencesSubElementVariants/KeyboardShortcutsTab.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import { Divider, Typography } from '@mui/material';
 import StyledTextField from '@/app/_components/_sharedcomponents/_styledcomponents/StyledTextField';
 import { ChangeEvent, useState } from 'react';

--- a/src/app/lobby/page.tsx
+++ b/src/app/lobby/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React, { useEffect } from 'react';
-import { Grid2 as Grid } from '@mui/material';
+import { Grid } from '@mui/material';
 import { usePathname, useRouter } from 'next/navigation';
 import Players from '../_components/Lobby/Players/Players';
 import Deck from '../_components/Lobby/Deck/Deck';

--- a/src/app/mod/layout.tsx
+++ b/src/app/mod/layout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Box, Typography } from '@mui/material';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import { s3ImageURL } from '@/app/_utils/s3Utils';
 
 

--- a/src/app/mod/page.tsx
+++ b/src/app/mod/page.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/app/_utils/auth';
-import { Box, Alert } from '@mui/material';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
 import Link from 'next/link';
 import ModPageClient from './ModPageClient';
 import { ServerApiService } from '../_services/ServerApiService';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import { Typography } from '@mui/material';
 import KarabastBanner from './_components/_sharedcomponents/Banner/Banner';
 import PublicGames from './_components/HomePage/PublicGames/PublicGames';

--- a/src/app/quickGame/page.tsx
+++ b/src/app/quickGame/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React, { useEffect } from 'react';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import { Box, Typography } from '@mui/material';
 import FoundGame from '@/app/_components/QuickGame/FoundGame/FoundGame';
 import { useGame } from '@/app/_contexts/Game.context';


### PR DESCRIPTION
I went through carefully [the migration guide](https://mui.com/material-ui/migration/upgrade-to-v7/) to update the MUI version.  



# Why migrate?

I would like to work on #663 and use the new `NumberField` MUI component from `v7`
<img width="1470" height="603" alt="Screenshot 2026-05-26 at 8 57 30 AM" src="https://github.com/user-attachments/assets/884c509f-9d71-4bec-8631-d679536b5c00" />

Also:
 - Old versions tie you to old version of other libraries
 - Be able to use newer stuff and the new docs
 - Vulnerabilities