### PR TITLE
Add width to avoid problems on larger screens

### DIFF
--- a/src/app/_components/_sharedcomponents/Popup/Popup.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/Popup.tsx
@@ -26,7 +26,8 @@ export const getPopupPosition = (type: PopupType, data: PopupData, index: number
         left:'50%',
         top: '50%',
         transform: 'translate(-50%, -50%)',
-        minWidth: '80%'
+        minWidth: '80%',
+        width: { xs: 'calc(100dvw - 2rem)', md: '80%' }
     };
 
     // const pilePosition = {


### PR DESCRIPTION
# Resources 

Checking resources on desktop
<img width="3134" height="1722" alt="localhost_3000_GameBoard" src="https://github.com/user-attachments/assets/097f4bfe-9921-49fb-bc75-9e88d1b63510" />

Checking resources on mobile/portrait
<img width="450" alt="localhost_3000_GameBoard(iPhone SE) (1)" src="https://github.com/user-attachments/assets/dda02bae-3a42-4467-aa0e-2eddcc37a8a8" />

Checking resources on mobile/landscape
<img width="1334" height="750" alt="localhost_3000_GameBoard(iPhone SE)" src="https://github.com/user-attachments/assets/4b7b0c8f-024d-4da2-b11d-07b01c842482" />

# Display long select cards popup

Select card from deck on desktop
<img width="3134" height="1722" alt="localhost_3000_GameBoard (1)" src="https://github.com/user-attachments/assets/2c6025e3-1d91-4d4b-989c-acbb8eff6036" />

Select card from deck on mobile/portrait
<img width="450" alt="localhost_3000_GameBoard(iPhone SE) (2)" src="https://github.com/user-attachments/assets/54086111-098c-4603-9033-198ae741f0d7" />

Select card from deck on mobile/landscape
<img width="1334" height="750" alt="localhost_3000_GameBoard(iPhone SE) (3)" src="https://github.com/user-attachments/assets/b3a53198-b8f4-4a41-b939-f5cb191dbfdd" />
