### PR TITLE
Remove gap space by removing empty elements

### DIFF
--- a/src/app/_components/_sharedcomponents/Popup/PopupVariant/SelectCardsPopup.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/PopupVariant/SelectCardsPopup.tsx
@@ -123,7 +123,7 @@ export const SelectCardsPopupModal = ({ data }: ButtonProps) => {
                                         onClick={() => handleCardClick(card.uuid)}
                                         disabled={clickDisabled()}
                                     />
-                                    <Typography>{card.displayText}</Typography>
+                                    {card.displayText && <Typography>{card.displayText}</Typography>}
                                     {selectingCards && (
                                         <Box
                                             sx={{
@@ -172,6 +172,9 @@ export const SelectCardsPopupModal = ({ data }: ButtonProps) => {
     };
 
     const renderButtons = (cardUuid: string, buttons: PerCardButton[]) => {
+        if (buttons.length === 0) {
+            return null;
+        }
         return (
             <Box sx={{ gap: '1rem', flexDirection: 'column', display: 'flex' }}>
                 {buttons.map((button, index) =>


### PR DESCRIPTION
The space between cell elements in the Select Cards Popup seemed off. The cell container has a `gap: 1rem` which adds spacing if there're empty elements.

Examples:
<img width="450" alt="Screenshot 2026-05-28 at 10 48 27 AM" src="https://github.com/user-attachments/assets/3f228c0c-08ab-42d7-8f02-f89d2d0dabb8" />

<img width="450" alt="Screenshot 2026-05-28 at 10 48 41 AM" src="https://github.com/user-attachments/assets/81332e95-6e32-4698-886b-dc58c2c49806" />


After fix:
<img width="1345" height="935" alt="Screenshot 2026-05-28 at 10 34 38 AM" src="https://github.com/user-attachments/assets/02bcd09b-7254-467f-9d19-a1f3659f2cf4" />
<img width="1343" height="937" alt="Screenshot 2026-05-28 at 10 34 53 AM" src="https://github.com/user-attachments/assets/d39ec096-3180-4474-9a94-8aa0a07569b4" />
<img width="1337" height="924" alt="Screenshot 2026-05-28 at 10 46 53 AM" src="https://github.com/user-attachments/assets/0618e2d0-df76-48c9-bda3-eff9164c160c" />
