### PR TITLE
Make timer smaller on mobile

### DIFF
--- a/src/app/_components/Gameboard/OpponentCardTray/OpponentCardTray.tsx
+++ b/src/app/_components/Gameboard/OpponentCardTray/OpponentCardTray.tsx
@@ -107,8 +107,9 @@ const OpponentCardTray: React.FC<IOpponentCardTrayProps> = ({ trayPlayer, prefer
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'flex-end',
-            padding: '1rem 2rem 1rem 0',
-            gap: '1rem',
+            py: '1rem',
+            pr: { xs: '1rem', md: '2rem' },
+            gap: { xs: hasLastPlayedCard ? '1rem' : '0', md: '1rem' },
         },
         lastPlayed: {
             ...debugBorder('yellow'),

--- a/src/app/_components/Gameboard/_subcomponents/OpponentTray/GameTimer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/OpponentTray/GameTimer.tsx
@@ -145,6 +145,13 @@ const TooltipContent = (
     )
 }
 
+const labelDefaultStyles = {
+    marginBottom: 0,
+    cursor: 'pointer',
+    fontWeight: 600,
+    fontSize: { xs: '1.5rem', md: '1rem' }
+};
+
 const MainTimerLabel = ({
     playerIsActive,
     opponentIsActive,
@@ -165,24 +172,20 @@ const MainTimerLabel = ({
             <Typography
                 variant="body1"
                 sx={{
+                    ...labelDefaultStyles,
                     color: 'var(--initiative-red)',
-                    marginBottom: 0,
-                    cursor: 'pointer',
                     opacity: opponentIsActive && !opponentIsTurnTime ? 1 : 0.65,
-                    fontWeight:600,
                 }}
-            >{`${formatMilliseconds(opponentTimeRemaining)}`}</Typography>
+            >{formatMilliseconds(opponentTimeRemaining)}</Typography>
             <Divider />
             <Typography
                 variant="body1"
                 sx={{
+                    ...labelDefaultStyles,
                     color: 'var(--initiative-blue)',
-                    marginBottom: 0,
-                    cursor: 'pointer',
                     opacity: playerIsActive && !playerIsTurnTime ? 1 : 0.65,
-                    fontWeight:600,
                 }}
-            >{`${formatMilliseconds(playerTimeRemaining)}`}</Typography>
+            >{formatMilliseconds(playerTimeRemaining)}</Typography>
         </Stack>
     )
 }

--- a/src/app/_components/_sharedcomponents/Timer/Timer.tsx
+++ b/src/app/_components/_sharedcomponents/Timer/Timer.tsx
@@ -63,7 +63,7 @@ const Timer: React.FC<TimerProps> = ({
                     )
             }
         >
-            <Box sx={{ position: 'relative', display: 'inline-flex' }}>
+            <Box sx={{ position: 'relative', display: 'inline-flex', transform: { xs: 'scale(0.7)', md: 'none' } }}>
                 <CircularProgress
                     variant='determinate'
                     size={80}


### PR DESCRIPTION
The goal is to avoid elements from overlapping.

# Current behavior

<img width="900" src="https://github.com/user-attachments/assets/08c49801-c8ed-4cee-8670-71bc0db571cc" />
<img width="450" src="https://github.com/user-attachments/assets/6ded0b4b-7a60-4c37-b316-edeb7d92054d" />


# New behavior

<img width="450" src="https://github.com/user-attachments/assets/7bc9b178-8249-43ea-b8be-44ba05eb9a79" />
<img width="900" src="https://github.com/user-attachments/assets/a29bd23c-ada7-4671-886a-6ca61aee3b13" />
