### PR TITLE
Add logic to hide language support for english speaking users

### DIFF
--- a/src/app/_utils/ServerAndLocalStorageUtils.ts
+++ b/src/app/_utils/ServerAndLocalStorageUtils.ts
@@ -939,7 +939,7 @@ export const unlinkSwubaseAsync = async(
     }
 };
 
-
+const isEnglishUser = () => (navigator?.language || 'en').includes('en');
 
 export const shouldShowAnnouncement = (announcement: IAnnouncement): boolean =>{
     try {
@@ -954,6 +954,12 @@ export const shouldShowAnnouncement = (announcement: IAnnouncement): boolean =>{
             return false; // Past end date, don't show
         }
         const hasSeenIt = localStorage.getItem(`swu-announcement-${announcement.key}`) !== null;
+
+        // TODO remove this hardcoded logic once we have some i18n support
+        if (announcement.key === 'cardLanguageSupport' && !hasSeenIt) {
+            return !isEnglishUser();
+        }
+
         return !hasSeenIt;
     }catch(error){
         console.error('Error checking if announcement should be shown:', error);


### PR DESCRIPTION
Let's hide the language support card feature for english speaking users.

If we want to display it for longer, we should update the expiration too.