### PR TITLE
Fix public games on mobile

### DIFF
--- a/src/app/_components/HomePage/_subcomponents/JoinableGame/JoinableGame.tsx
+++ b/src/app/_components/HomePage/_subcomponents/JoinableGame/JoinableGame.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
-import { Box, Button, Typography, Popover, PopoverOrigin } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
 import { useRouter } from 'next/navigation';
 import { useUser } from '@/app/_contexts/User.context';
 import { IJoinableGameProps } from '../../HomePageTypes';
-import { s3CardImageURL } from '@/app/_utils/s3Utils';
-import { useCardImageLocale } from '@/app/_contexts/CardImageLocale.context';
-import { CardStyle, ISetCode } from '@/app/_components/_sharedcomponents/Cards/CardTypes';
+import { ISetCode } from '@/app/_components/_sharedcomponents/Cards/CardTypes';
+import OverlappingCards from '../OverlappingCards/OverlappingCards';
 import { ILobbyCardData } from '../../HomePageTypes';
 import { getUserPayload } from '@/app/_utils/ServerAndLocalStorageUtils';
-import { FormatLabels, FormatTagLabels, SwuGameFormat, GamesToWinMode, CardPool, CardPoolLabels } from '@/app/_constants/constants';
+import { FormatTagLabels, SwuGameFormat, GamesToWinMode, CardPool, CardPoolLabels } from '@/app/_constants/constants';
 import PremierIcon from '/public/premier.svg';
 import EternalIcon from '/public/eternal.svg';
 import OpenIcon from '/public/open.svg';
@@ -19,42 +18,7 @@ import Bo3Icon from '/public/bo3.svg';
 const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
     const router = useRouter();
     const { user } = useUser();
-    const locale = useCardImageLocale();
-    const [anchorElement, setAnchorElement] = React.useState<HTMLElement | null>(null);
-    const [previewImage, setPreviewImage] = React.useState<string | null>(null);
-    const hoverTimeout = React.useRef<number | undefined>(undefined);
-    const open = Boolean(anchorElement);
 
-    const handlePreviewOpen = (event: React.MouseEvent<HTMLElement>) => {
-        const target = event.currentTarget;
-        const imageUrl = target.getAttribute('data-card-url');
-
-        if (!imageUrl) return;
-
-        hoverTimeout.current = window.setTimeout(() => {
-            setAnchorElement(target);
-            setPreviewImage(`url(${imageUrl})`);
-        }, 300);
-    };
-
-    const handlePreviewClose = () => {
-        clearTimeout(hoverTimeout.current);
-        setAnchorElement(null);
-        setPreviewImage(null);
-    };
-
-    const popoverConfig = (): { anchorOrigin: PopoverOrigin, transformOrigin: PopoverOrigin } => {
-        return {
-            anchorOrigin: {
-                vertical: 'center',
-                horizontal: 'right',
-            },
-            transformOrigin: {
-                vertical: 'center',
-                horizontal: 'left',
-            }
-        };
-    };
     const joinLobby = async (lobbyId: string) => {
         try {
             const payload = {
@@ -132,6 +96,7 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
         },
         lobbyInfo: {
             display: 'flex',
+            flex: 1,
             alignItems: 'flex-start',
             gap: '1rem',
         },
@@ -299,93 +264,54 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
     };
 
     return (
-        <>
-            <Box sx={styles.box} key={lobby.id}>
-                <Box sx={styles.lobbyInfo}>
-                    {lobby.host && (
-                        <Box sx={styles.cardsContainer}>
-                            <Box sx={{ position: 'relative' }}>
-                                <Box>
-                                    <Box 
-                                        sx={{
-                                            ...styles.cardPreview,
-                                            backgroundImage: `url(${s3CardImageURL(createCardObject(lobby.host.base), locale, CardStyle.Plain)})`
-                                        }}
-                                        title={`Base: ${lobby.host.base.id}`}
-                                        onMouseEnter={handlePreviewOpen}
-                                        onMouseLeave={handlePreviewClose}
-                                        data-card-url={s3CardImageURL(createCardObject(lobby.host.base), locale, CardStyle.Plain)}
-                                    >
-                                    </Box>
-                                </Box>
-                                <Box sx={styles.parentBoxStyling}>
-                                    <Box 
-                                        sx={{
-                                            ...styles.cardPreview,
-                                            backgroundImage: `url(${s3CardImageURL(createCardObject(lobby.host.leader), locale, CardStyle.PlainLeader)})`
-                                        }}
-                                        title={`Leader: ${lobby.host.leader.id}`}
-                                        onMouseEnter={handlePreviewOpen}
-                                        onMouseLeave={handlePreviewClose}
-                                        data-card-url={s3CardImageURL(createCardObject(lobby.host.leader), locale, CardStyle.PlainLeader)}
-                                    >
-                                    </Box>
-                                </Box>
-                            </Box>
+        <Box sx={styles.box} key={lobby.id}>
+            <Box sx={styles.lobbyInfo}>
+                {lobby.host && (
+                    <OverlappingCards
+                        sx={styles.cardsContainer}
+                        baseCard={createCardObject(lobby.host.base)}
+                        leaderCard={createCardObject(lobby.host.leader)}
+                    />
+                )}
+                <Box>
+                    <Typography variant="body1" sx={styles.matchType}>{lobby.name}</Typography>
+                    <Box sx={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginTop: '8px', marginBottom: '12px' }}>
+                        <Box
+                            sx={{
+                                ...styles.tags.lobbySetting,
+                                ...getGameFormatTagStyle(lobby.format),
+                            }}
+                        >
+                            {getFormatIcon(lobby.format)}
+                            { FormatTagLabels[lobby.format] || lobby.format.toUpperCase() }
                         </Box>
-                    )}
-                    <Box>
-                        <Typography variant="body1" sx={styles.matchType}>{lobby.name}</Typography>
-                        <Box sx={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginTop: '8px', marginBottom: '12px' }}>
+                        {lobby.cardPool !== 'unlimited' && (
+                        // Don't show unlimited card pool tag because it's never selectable
+                        // It's just the default card pool for Open lobbies
                             <Box
                                 sx={{
                                     ...styles.tags.lobbySetting,
-                                    ...getGameFormatTagStyle(lobby.format),
+                                    ...getCardPoolTagStyle(lobby.cardPool),
                                 }}
                             >
-                                {getFormatIcon(lobby.format)}
-                                { FormatTagLabels[lobby.format] || lobby.format.toUpperCase() }
+                                {getCardPoolIcon(lobby.cardPool)}
+                                { CardPoolLabels[lobby.cardPool] || lobby.cardPool.toUpperCase() }
                             </Box>
-                            {lobby.cardPool !== 'unlimited' && ( 
-                                // Don't show unlimited card pool tag because it's never selectable
-                                // It's just the default card pool for Open lobbies
-                                <Box
-                                    sx={{
-                                        ...styles.tags.lobbySetting,
-                                        ...getCardPoolTagStyle(lobby.cardPool),
-                                    }}
-                                >
-                                    {getCardPoolIcon(lobby.cardPool)}
-                                    { CardPoolLabels[lobby.cardPool] || lobby.cardPool.toUpperCase() }
-                                </Box>
-                            )}
-                            <Box
-                                sx={{
-                                    ...styles.tags.lobbySetting,
-                                    ...getGamesToWinTagStyle(lobby.gamesToWinMode),
-                                }}
-                            >
-                                {getGamesToWinIcon(lobby.gamesToWinMode)}
-                                {getGamesToWinLabel(lobby.gamesToWinMode)}
-                            </Box>
+                        )}
+                        <Box
+                            sx={{
+                                ...styles.tags.lobbySetting,
+                                ...getGamesToWinTagStyle(lobby.gamesToWinMode),
+                            }}
+                        >
+                            {getGamesToWinIcon(lobby.gamesToWinMode)}
+                            {getGamesToWinLabel(lobby.gamesToWinMode)}
                         </Box>
                     </Box>
                 </Box>
-                <Button onClick={() => joinLobby(lobby.id)}>Join</Button>
             </Box>
-            <Popover
-                id="mouse-over-popover"
-                sx={{ pointerEvents: 'none' }}
-                open={open}
-                anchorEl={anchorElement}
-                onClose={handlePreviewClose}
-                disableRestoreFocus
-                slotProps={{ paper: { sx: { backgroundColor: 'transparent' } } }}
-                {...popoverConfig()}
-            >
-                <Box sx={{ ...styles.cardPopover, backgroundImage: previewImage }} />
-            </Popover>
-        </>
+            <Button onClick={() => joinLobby(lobby.id)}>Join</Button>
+        </Box>
     );
 };
 

--- a/src/app/_components/HomePage/_subcomponents/JoinableGame/JoinableGame.tsx
+++ b/src/app/_components/HomePage/_subcomponents/JoinableGame/JoinableGame.tsx
@@ -56,7 +56,7 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
             alignContent: 'center',
             alignItems: 'center',
             mb: '1.25rem',
-            padding: '0.5rem 0',
+            gap: '1rem',
         },
         matchType: {
             margin: 0,
@@ -67,31 +67,6 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
         cardsContainer: {
             display: 'flex',
             alignItems: 'center',
-        },
-        parentBoxStyling: {
-            position: 'absolute',
-            left: '-15px',
-            top: '24px',
-        },
-        cardPreview: {
-            borderRadius: '0.5rem',
-            backgroundSize: 'cover',
-            width: 'clamp(3rem, 7vw, 10rem)',
-            aspectRatio: '1.39',
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            position: 'relative',
-            border: '2px solid transparent',
-            boxSizing: 'border-box',
-            cursor: 'pointer'
-        },
-        cardPopover: {
-            borderRadius: '.38em',
-            backgroundSize: 'cover',
-            backgroundRepeat: 'no-repeat',
-            aspectRatio: '1.4 / 1',
-            width: '24rem',
         },
         lobbyInfo: {
             display: 'flex',

--- a/src/app/_components/HomePage/_subcomponents/JoinableGame/JoinableGame.tsx
+++ b/src/app/_components/HomePage/_subcomponents/JoinableGame/JoinableGame.tsx
@@ -56,7 +56,8 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
             alignContent: 'center',
             alignItems: 'center',
             mb: '1.25rem',
-            gap: '1rem',
+            gap: { xs: '1rem', lg: '2rem' },
+            paddingLeft: '10px',
         },
         matchType: {
             margin: 0,
@@ -247,7 +248,7 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
                         leaderCard={createCardObject(lobby.host.leader)}
                     />
                 )}
-                <Box sx={{ minWidth: '50%' }}>
+                <Box sx={{ minWidth: '50%', width: '50%' }}>
                     <Typography variant="body1" sx={styles.matchType}>{lobby.name}</Typography>
                     <Box sx={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginTop: '8px', marginBottom: '12px' }}>
                         <Box

--- a/src/app/_components/HomePage/_subcomponents/JoinableGame/JoinableGame.tsx
+++ b/src/app/_components/HomePage/_subcomponents/JoinableGame/JoinableGame.tsx
@@ -67,7 +67,6 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
         cardsContainer: {
             display: 'flex',
             alignItems: 'center',
-            paddingLeft: '10px',
         },
         parentBoxStyling: {
             position: 'absolute',
@@ -273,7 +272,7 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
                         leaderCard={createCardObject(lobby.host.leader)}
                     />
                 )}
-                <Box>
+                <Box sx={{ minWidth: '50%' }}>
                     <Typography variant="body1" sx={styles.matchType}>{lobby.name}</Typography>
                     <Box sx={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginTop: '8px', marginBottom: '12px' }}>
                         <Box

--- a/src/app/_components/HomePage/_subcomponents/OverlappingCards/OverlappingCards.tsx
+++ b/src/app/_components/HomePage/_subcomponents/OverlappingCards/OverlappingCards.tsx
@@ -34,7 +34,7 @@ const styles = {
     cardsContainer: {
         position: 'relative',
         marginLeft: '7.5%',
-        marginBottom: '13%',
+        marginBottom: '8%',
         aspectRatio: '1.39',
         width: 'clamp(5rem, 100%, 8rem)', // Min 5rem, max 10rem, scales with viewport
     }

--- a/src/app/_components/HomePage/_subcomponents/OverlappingCards/OverlappingCards.tsx
+++ b/src/app/_components/HomePage/_subcomponents/OverlappingCards/OverlappingCards.tsx
@@ -33,8 +33,12 @@ const styles = {
     },
     cardsContainer: {
         position: 'relative',
-        marginLeft: '7.5%',
-        marginBottom: '8%',
+        width: 'clamp(5rem, 100%, 8rem)'
+        // marginLeft: '7.5%',
+        // marginBottom: '8%',
+
+    },
+    container: {
         aspectRatio: '1.39',
         width: 'clamp(5rem, 100%, 8rem)', // Min 5rem, max 10rem, scales with viewport
     }
@@ -71,19 +75,22 @@ export default function OverlappingCards({ baseCard, leaderCard, ...boxProps }: 
         setPreviewImage(null);
     };
     return (
-        <Box sx={[styles.cardsContainer, ...(Array.isArray(sx) ? sx : [sx])]} {...otherBoxProps}>
-            <Box
-                sx={{ ...styles.leaderStyleCard, backgroundImage:`url(${s3CardImageURL(baseCard, locale)})` }}
-                onMouseEnter={handlePreviewOpen}
-                onMouseLeave={handlePreviewClose}
-                data-card-url={s3CardImageURL(baseCard, locale)}
-            />
-            <Box
-                sx={[styles.leaderStyleCard, styles.leaderContainer, { backgroundImage:`url(${s3CardImageURL(leaderCard, locale, LeaderBaseCardStyle.PlainLeader)})` }]}
-                onMouseEnter={handlePreviewOpen}
-                onMouseLeave={handlePreviewClose}
-                data-card-url={s3CardImageURL(leaderCard, locale, LeaderBaseCardStyle.PlainLeader)}
-            />
+        <Box sx={[styles.container, ...(Array.isArray(sx) ? sx : [sx])]} {...otherBoxProps}>
+            <Box sx={styles.cardsContainer}>
+                <Box
+                    sx={{ ...styles.leaderStyleCard, backgroundImage:`url(${s3CardImageURL(baseCard, locale)})` }}
+                    onMouseEnter={handlePreviewOpen}
+                    onMouseLeave={handlePreviewClose}
+                    data-card-url={s3CardImageURL(baseCard, locale)}
+                />
+                <Box
+                    sx={[styles.leaderStyleCard, styles.leaderContainer, { backgroundImage:`url(${s3CardImageURL(leaderCard, locale, LeaderBaseCardStyle.PlainLeader)})` }]}
+                    onMouseEnter={handlePreviewOpen}
+                    onMouseLeave={handlePreviewClose}
+                    data-card-url={s3CardImageURL(leaderCard, locale, LeaderBaseCardStyle.PlainLeader)}
+                />
+            </Box>
+
             <Popover
                 id="mouse-over-popover"
                 sx={{ pointerEvents: 'none' }}

--- a/src/app/_components/HomePage/_subcomponents/OverlappingCards/OverlappingCards.tsx
+++ b/src/app/_components/HomePage/_subcomponents/OverlappingCards/OverlappingCards.tsx
@@ -36,7 +36,7 @@ const styles = {
         marginLeft: '7.5%',
         marginBottom: '13%',
         aspectRatio: '1.39',
-        width: 'clamp(5rem, 100%, 10rem)', // Min 5rem, max 10rem, scales with viewport
+        width: 'clamp(5rem, 100%, 8rem)', // Min 5rem, max 10rem, scales with viewport
     }
 };
 

--- a/src/app/_components/HomePage/_subcomponents/OverlappingCards/OverlappingCards.tsx
+++ b/src/app/_components/HomePage/_subcomponents/OverlappingCards/OverlappingCards.tsx
@@ -1,0 +1,107 @@
+import { ICardData, ISetCode, LeaderBaseCardStyle } from '@/app/_components/_sharedcomponents/Cards/CardTypes';
+import React from 'react';
+import { useCardImageLocale } from '@/app/_contexts/CardImageLocale.context';
+import { Box, BoxProps, Popover } from '@mui/material';
+import { s3CardImageURL } from '@/app/_utils/s3Utils';
+
+const styles = {
+    cardPopover: {
+        borderRadius: '.38em',
+        backgroundSize: 'cover',
+        backgroundRepeat: 'no-repeat',
+        aspectRatio: '1.4 / 1',
+        width: '24rem',
+    },
+    leaderStyleCard:{
+        borderRadius: '0.5rem',
+        backgroundSize: 'cover',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        position: 'relative',
+        border: '2px solid transparent',
+        boxSizing: 'border-box',
+        cursor: 'pointer',
+        aspectRatio: '1.39',
+        width: '100%',
+    },
+    leaderContainer: {
+        position:'absolute',
+        left:'-11.5%',
+        top:'25%',
+        width: '100%',
+    },
+    cardsContainer: {
+        position: 'relative',
+        marginLeft: '7.5%',
+        marginBottom: '13%',
+        aspectRatio: '1.39',
+        width: 'clamp(5rem, 100%, 10rem)', // Min 5rem, max 10rem, scales with viewport
+    }
+};
+
+export type OverlappingCardProps = BoxProps & { baseCard: ICardData | ISetCode, leaderCard: ICardData | ISetCode };
+
+/**
+ * Parent must provide with width to be able to occupy the available space (but maintaining the aspect ratio of the card)
+ */
+export default function OverlappingCards({ baseCard, leaderCard, ...boxProps }: OverlappingCardProps) {
+    const { sx = {}, ...otherBoxProps } = boxProps || {};
+    const [anchorElement, setAnchorElement] = React.useState<HTMLElement | null>(null);
+    const [previewImage, setPreviewImage] = React.useState<string | null>(null);
+    const locale = useCardImageLocale();
+    const hoverTimeout = React.useRef<number | undefined>(undefined);
+    const open = Boolean(anchorElement);
+
+    const handlePreviewOpen = (event: React.MouseEvent<HTMLElement>) => {
+        const target = event.currentTarget;
+        const imageUrl = target.getAttribute('data-card-url');
+
+        if (!imageUrl) return;
+
+        hoverTimeout.current = window.setTimeout(() => {
+            setAnchorElement(target);
+            setPreviewImage(`url(${imageUrl})`);
+        }, 300);
+    };
+    const handlePreviewClose = () => {
+        clearTimeout(hoverTimeout.current);
+        hoverTimeout.current = undefined;
+        setAnchorElement(null);
+        setPreviewImage(null);
+    };
+    return (
+        <Box sx={[styles.cardsContainer, ...(Array.isArray(sx) ? sx : [sx])]} {...otherBoxProps}>
+            <Box
+                sx={{ ...styles.leaderStyleCard, backgroundImage:`url(${s3CardImageURL(baseCard, locale)})` }}
+                onMouseEnter={handlePreviewOpen}
+                onMouseLeave={handlePreviewClose}
+                data-card-url={s3CardImageURL(baseCard, locale)}
+            />
+            <Box
+                sx={[styles.leaderStyleCard, styles.leaderContainer, { backgroundImage:`url(${s3CardImageURL(leaderCard, locale, LeaderBaseCardStyle.PlainLeader)})` }]}
+                onMouseEnter={handlePreviewOpen}
+                onMouseLeave={handlePreviewClose}
+                data-card-url={s3CardImageURL(leaderCard, locale, LeaderBaseCardStyle.PlainLeader)}
+            />
+            <Popover
+                id="mouse-over-popover"
+                sx={{ pointerEvents: 'none' }}
+                open={open}
+                anchorEl={anchorElement}
+                onClose={handlePreviewClose}
+                disableRestoreFocus
+                slotProps={{ paper: { sx: { backgroundColor: 'transparent' } } }}
+                anchorOrigin={{
+                    vertical: 'center',
+                    horizontal: 'right',
+                }}
+                transformOrigin={{
+                    vertical: 'center',
+                    horizontal: 'left',
+                }}>
+                <Box sx={{ ...styles.cardPopover, backgroundImage: previewImage }} />
+            </Popover>
+        </Box>
+    );
+}

--- a/src/app/_components/HomePage/_subcomponents/PublicMatch/PublicMatch.tsx
+++ b/src/app/_components/HomePage/_subcomponents/PublicMatch/PublicMatch.tsx
@@ -13,7 +13,7 @@ const styles = {
         alignItems: 'center',
         mb: '2.5rem',
         pl: '10px',
-        gap: '1rem',
+        gap: '2rem',
     },
     matchItems: {
         display: 'flex',
@@ -25,9 +25,6 @@ const styles = {
         margin: 0,
         mr: '1rem',
     },
-    overlappingCard: {
-        width: 'clamp(5rem, 100%, 14rem)', // Min 5rem, max 10rem, scales with viewport
-    }
 };
 
 const PublicMatch: React.FC<IPublicGameInProgressProps> = ({ match }) => {
@@ -44,11 +41,11 @@ const PublicMatch: React.FC<IPublicGameInProgressProps> = ({ match }) => {
         <Box sx={styles.box}>
             <Box sx={styles.matchItems}>
                 <Box sx={{ position:'relative', flex: 1 }}>
-                    <OverlappingCards sx={styles.overlappingCard} baseCard={match.player1Base} leaderCard={match.player1Leader} />
+                    <OverlappingCards baseCard={match.player1Base} leaderCard={match.player1Leader} />
                 </Box>
                 <Typography variant="body1" sx={styles.matchType}>vs</Typography>
                 <Box sx={{ position:'relative', flex: 1 }}>
-                    <OverlappingCards sx={styles.overlappingCard} baseCard={match.player2Base} leaderCard={match.player2Leader} />
+                    <OverlappingCards baseCard={match.player2Base} leaderCard={match.player2Leader} />
                 </Box>
             </Box>
             {!match.isPrivate && (

--- a/src/app/_components/HomePage/_subcomponents/PublicMatch/PublicMatch.tsx
+++ b/src/app/_components/HomePage/_subcomponents/PublicMatch/PublicMatch.tsx
@@ -1,52 +1,38 @@
 import React from 'react';
-import { Box, Button, Typography, Popover, PopoverOrigin } from '@mui/material';
-import GameInProgressPlayer from '../GameInProgressPlayer/GameInProgressPlayer';
+import { Box, Button, Typography } from '@mui/material';
 import { IPublicGameInProgressProps } from '../../HomePageTypes';
-import { s3CardImageURL } from '@/app/_utils/s3Utils';
-import { useCardImageLocale } from '@/app/_contexts/CardImageLocale.context';
 import { useRouter } from 'next/navigation';
 import { useUser } from '@/app/_contexts/User.context';
-import { LeaderBaseCardStyle } from '@/app/_components/_sharedcomponents/Cards/CardTypes';
+import OverlappingCards from '../OverlappingCards/OverlappingCards';
+
+const styles = {
+    box: {
+        width: '100%',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        mb: '2.5rem',
+        pl: '10px',
+        gap: '1rem',
+    },
+    matchItems: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '1rem',
+        flex: 1,
+    },
+    matchType: {
+        margin: 0,
+        mr: '1rem',
+    },
+    overlappingCard: {
+        width: 'clamp(5rem, 100%, 14rem)', // Min 5rem, max 10rem, scales with viewport
+    }
+};
 
 const PublicMatch: React.FC<IPublicGameInProgressProps> = ({ match }) => {
     const router = useRouter();
     const { user } = useUser();
-    const locale = useCardImageLocale();
-    const [anchorElement, setAnchorElement] = React.useState<HTMLElement | null>(null);
-    const [previewImage, setPreviewImage] = React.useState<string | null>(null);
-    const hoverTimeout = React.useRef<number | undefined>(undefined);
-    const open = Boolean(anchorElement);
-
-    const handlePreviewOpen = (event: React.MouseEvent<HTMLElement>) => {
-        const target = event.currentTarget;
-        const imageUrl = target.getAttribute('data-card-url');
-
-        if (!imageUrl) return;
-
-        hoverTimeout.current = window.setTimeout(() => {
-            setAnchorElement(target);
-            setPreviewImage(`url(${imageUrl})`);
-        }, 300);
-    };
-
-    const handlePreviewClose = () => {
-        clearTimeout(hoverTimeout.current);
-        setAnchorElement(null);
-        setPreviewImage(null);
-    };
-
-    const popoverConfig = (): { anchorOrigin: PopoverOrigin, transformOrigin: PopoverOrigin } => {
-        return {
-            anchorOrigin: {
-                vertical: 'center',
-                horizontal: 'right',
-            },
-            transformOrigin: {
-                vertical: 'center',
-                horizontal: 'left',
-            }
-        };
-    };
 
     const handleSpectate = () => {
         router.push(`/spectate?lobbyId=${match.id}`);
@@ -54,115 +40,28 @@ const PublicMatch: React.FC<IPublicGameInProgressProps> = ({ match }) => {
 
     const spectateDisabled = !user && process.env.NODE_ENV !== 'development';
 
-    const styles = {
-        cardPopover: {
-            borderRadius: '.38em',
-            backgroundSize: 'cover',
-            backgroundRepeat: 'no-repeat',
-            aspectRatio: '1.4 / 1',
-            width: '24rem',
-        },
-        box: {
-            width: '100%',
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            mb: '2.5rem',
-            pl: '10px',
-        },
-        matchItems: {
-            display: 'flex',
-            alignItems: 'center',
-            gap: '1rem',
-        },
-        matchType: {
-            margin: 0,
-            mr: '1rem',
-        },
-        leaderStyleCard:{
-            borderRadius: '0.5rem',
-            backgroundSize: 'cover',
-            width: 'clamp(3rem, 7vw, 10rem)', // Min 5rem, max 10rem, scales with viewport
-            aspectRatio: '1.39',
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            position: 'relative',
-            border: '2px solid transparent',
-            boxSizing: 'border-box',
-            cursor: 'pointer'
-        },
-        parentBoxStyling: {
-            position:'absolute',
-        },
-    };
-
     return (
-        <>
-            <Box sx={styles.box}>
-                <Box sx={styles.matchItems}>
-                    <Box sx={{ position:'relative' }}>
-                        <Box>
-                            <Box 
-                                sx={{ ...styles.leaderStyleCard,backgroundImage:`url(${s3CardImageURL(match.player1Base, locale)})` }}
-                                onMouseEnter={handlePreviewOpen}
-                                onMouseLeave={handlePreviewClose}
-                                data-card-url={s3CardImageURL(match.player1Base, locale)}
-                            />
-                        </Box>
-                        <Box sx={{ ...styles.parentBoxStyling,left:'-15px',top:'24px' }}>
-                            <Box 
-                                sx={{ ...styles.leaderStyleCard,backgroundImage:`url(${s3CardImageURL(match.player1Leader, locale, LeaderBaseCardStyle.PlainLeader)})` }}
-                                onMouseEnter={handlePreviewOpen}
-                                onMouseLeave={handlePreviewClose}
-                                data-card-url={s3CardImageURL(match.player1Leader, locale, LeaderBaseCardStyle.PlainLeader)}
-                            />
-                        </Box>
-                    </Box>
-                    <Typography variant="body1" sx={styles.matchType}>vs</Typography>
-                    <Box sx={{ position:'relative' }}>
-                        <Box>
-                            <Box 
-                                sx={{ ...styles.leaderStyleCard,backgroundImage:`url(${s3CardImageURL(match.player2Base, locale)})` }}
-                                onMouseEnter={handlePreviewOpen}
-                                onMouseLeave={handlePreviewClose}
-                                data-card-url={s3CardImageURL(match.player2Base, locale)}
-                            />
-                        </Box>
-                        <Box sx={{ ...styles.parentBoxStyling,left:'-15px',top:'24px' }}>
-                            <Box 
-                                sx={{ ...styles.leaderStyleCard,backgroundImage:`url(${s3CardImageURL(match.player2Leader, locale, LeaderBaseCardStyle.PlainLeader)})` }}
-                                onMouseEnter={handlePreviewOpen}
-                                onMouseLeave={handlePreviewClose}
-                                data-card-url={s3CardImageURL(match.player2Leader, locale, LeaderBaseCardStyle.PlainLeader)}
-                            />
-                        </Box>
-                    </Box>
+        <Box sx={styles.box}>
+            <Box sx={styles.matchItems}>
+                <Box sx={{ position:'relative', flex: 1 }}>
+                    <OverlappingCards sx={styles.overlappingCard} baseCard={match.player1Base} leaderCard={match.player1Leader} />
                 </Box>
-                {!match.isPrivate && (
-                    <span title={spectateDisabled ? 'Log in to Spectate' : ''}>
-                        <Button
-                            onClick={handleSpectate}
-                            disabled={spectateDisabled}
-                        >
-                            Spectate
-                        </Button>
-                    </span>
-                )}
+                <Typography variant="body1" sx={styles.matchType}>vs</Typography>
+                <Box sx={{ position:'relative', flex: 1 }}>
+                    <OverlappingCards sx={styles.overlappingCard} baseCard={match.player2Base} leaderCard={match.player2Leader} />
+                </Box>
             </Box>
-            <Popover
-                id="mouse-over-popover"
-                sx={{ pointerEvents: 'none' }}
-                open={open}
-                anchorEl={anchorElement}
-                onClose={handlePreviewClose}
-                disableRestoreFocus
-                slotProps={{ paper: { sx: { backgroundColor: 'transparent' } } }}
-                {...popoverConfig()}
-            >
-                <Box sx={{ ...styles.cardPopover, backgroundImage: previewImage }} />
-            </Popover>
-        </>
+            {!match.isPrivate && (
+                <span title={spectateDisabled ? 'Log in to Spectate' : ''}>
+                    <Button
+                        onClick={handleSpectate}
+                        disabled={spectateDisabled}
+                    >
+                        Spectate
+                    </Button>
+                </span>
+            )}
+        </Box>
     );
 };
 


### PR DESCRIPTION
## Goal

Fix how public games are shown on mobile.

<img height="450" src="https://github.com/user-attachments/assets/9965d3b7-2510-45b6-bd91-5aa4fce6dea2" />

## Solution
Create a common component `OverlappingCards` so both lobbies and games can share the same logic.  


<img height="450" alt="mobile_fix" src="https://github.com/user-attachments/assets/f9daa1d4-31c4-4e13-bf4b-06dbe2d649ac" />


## Desktop (before and after for reference)

Before

<img width="1664" height="961" alt="Screenshot 2026-06-02 at 2 27 15 PM" src="https://github.com/user-attachments/assets/c8b5902f-7e36-4332-bcc5-8376245d74c7" />

After

<img width="1662" height="957" alt="with_fix" src="https://github.com/user-attachments/assets/5622fa66-93d9-44b8-afc2-961b8ab721ca" />

