### PR TITLE
Preferences UI fixes

### DIFF
--- a/src/app/Preferences/page.tsx
+++ b/src/app/Preferences/page.tsx
@@ -28,16 +28,18 @@ const PreferencesInner: React.FC = () => {
             zIndex: 2
         },
         mainContainer:{
-            height: '100vh',
-            overflow: 'hidden',
+            minHeight: '100vh',
+            height: { xs: 'auto', md: '100vh' },
+            overflowX: 'hidden',
+            overflowY: { xs: 'visible', md: 'hidden' },
             backgroundImage: `url(${s3ImageURL('ui/board-background-1.webp')})`,
             backgroundSize: 'cover',
             backgroundPosition: 'center',
             display:'grid',
         },
         disclaimer: {
-            position: 'absolute',
-            bottom: 0,
+            position: { xs: 'relative', md: 'absolute' },
+            bottom: { xs: 'auto', md: 0 },
             width: '100%',
             padding: '1rem',
             textAlign: 'center',

--- a/src/app/_components/_sharedcomponents/Preferences/PreferencesComponent.tsx
+++ b/src/app/_components/_sharedcomponents/Preferences/PreferencesComponent.tsx
@@ -37,7 +37,8 @@ const PreferencesComponent: React.FC<IPreferenceProps> = ({
             padding: variant === 'homePage' ? { xs: '7rem 2rem', md:'7rem' } : '2rem',
         },
         overlayStyle:{
-            display: isPreferenceOpen ? 'block' : 'none',
+            display: isPreferenceOpen ? 'flex' : 'none',
+            flexDirection: 'column',
             padding: '30px',
             maxWidth: '105em',
             // nothing should display outside the popup. use inner scrolls to display the content
@@ -71,7 +72,8 @@ const PreferencesComponent: React.FC<IPreferenceProps> = ({
             top:'30px',
         },
         tabContainer:{
-            height:'30rem',
+            flex: 1,
+            minHeight: 0,
             background: 'transparent',
         },
         titleContainer:{

--- a/src/app/_components/_sharedcomponents/Preferences/PreferencesComponent.tsx
+++ b/src/app/_components/_sharedcomponents/Preferences/PreferencesComponent.tsx
@@ -29,12 +29,13 @@ const PreferencesComponent: React.FC<IPreferenceProps> = ({
     const styles = {
         containerStyle:{
             display: isPreferenceOpen ? 'block' : 'none',
-            position: 'absolute',
+            position: variant === 'homePage' ? { xs: 'relative', md: 'absolute' } : 'absolute',
             width: sidebarOpen ? { xs: '100%', md: 'calc(100% - min(20%, 280px))' } : '100%',
-            height: '100%',
+            height: variant === 'homePage' ? { xs: 'auto', md: '100%' } : '100%',
             backgroundColor: variant ==='gameBoard' ? 'rgba(0, 0, 0, 0.5)' : 'none',
             zIndex: variant === 'homePage' ? 1 : 999,
             padding: variant === 'homePage' ? { xs: '7rem 2rem', md:'7rem' } : '2rem',
+            maxWidth: { xs: '100vw', md: '100%' },
         },
         overlayStyle:{
             display: isPreferenceOpen ? 'flex' : 'none',
@@ -51,7 +52,7 @@ const PreferencesComponent: React.FC<IPreferenceProps> = ({
             ...(variant === 'homePage' ? {
                 width: '100%',
                 justifySelf:'center',
-                height: '81vh',
+                height: { xs: 'auto', md: '81vh' },
             } : {
                 borderColor: '#30434B',
                 height: '100%',

--- a/src/app/_components/_sharedcomponents/Preferences/_subComponents/VerticalTabs.tsx
+++ b/src/app/_components/_sharedcomponents/Preferences/_subComponents/VerticalTabs.tsx
@@ -187,9 +187,11 @@ function VerticalTabs({
         tabPanelContainer:{
             backgroundColor: 'transparent',
             width: { xs: 'auto', md: '80%' },
+            flex: 1,
+            minHeight: 0,
             pl: { xs: 0, md: 9 },
             gap: '20px',
-            maxHeight: variant === 'gameBoard' ? 'calc(80vh - 1rem)' : 'calc(100vh - 14rem - 60px)',
+            maxHeight: '100%',
             overflowY: 'auto',
             '::-webkit-scrollbar': {
                 width: '0.2vw',
@@ -207,7 +209,7 @@ function VerticalTabs({
 
     return (
         <Box
-            sx={{ display: 'flex', background: 'transparent', flexDirection: { xs: 'column', md: 'row' } }}
+            sx={{ display: 'flex', background: 'transparent', flexDirection: { xs: 'column', md: 'row' }, height: '100%', minHeight: 0 }}
         >
             <Tabs
                 orientation={isSmallScreen ? 'horizontal' : 'vertical'}

--- a/src/app/_components/_sharedcomponents/Preferences/_subComponents/VerticalTabs.tsx
+++ b/src/app/_components/_sharedcomponents/Preferences/_subComponents/VerticalTabs.tsx
@@ -56,7 +56,7 @@ function VerticalTabs({
     const [pendingTabIndex, setPendingTabIndex] = useState<number | null>(null);
     const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
     const { logout } = useUser();
-    const isSmallScreen = useMediaQuery('(max-width: 1280px)');
+    const isSmallScreen = useMediaQuery('(max-width: 899px)');
 
     useEffect(() => {
         const handleBeforeUnload = (e: BeforeUnloadEvent) => {


### PR DESCRIPTION
Preferences fixes:

 - [In Game/Mobile/Landscape] Report opponent not reachable 
 - [Preferences page/Mobile] Preferences should be allowed to grow vertically instead of adding scrolling inside the card
 - From 800px to 1280px screens, tabs orientation were not in alignment with styles breakpoints.  

# Problems

Report opponent unreachable

https://github.com/user-attachments/assets/cc63037c-1ada-40b1-89fd-1d6dc7e5e11d

Preference page doesn't grow vertically on mobile

<img width="389" height="846" alt="Screenshot 2026-06-09 at 8 40 17 AM" src="https://github.com/user-attachments/assets/1edb02ae-13ef-4a5b-b4d1-6ecafd5bba9f" />

From 800px to 1280px screens, tabs orientation were not in alignment with styles breakpoints.  

https://github.com/user-attachments/assets/9b278235-5291-401a-a865-967118178d94

# Fixes

Now "Report Opponent" button is reachable

https://github.com/user-attachments/assets/6094207f-1aad-4242-9ebb-4a707385e5b3

Allow preferences page to grow vertically on mobile

<img width="389" src="https://github.com/user-attachments/assets/39919af6-73ce-4591-8b27-9c55928718e0" />

From 800px to 1280px screens, tabs orientation are in alignment with styles breakpoints.  

https://github.com/user-attachments/assets/7635bd38-046d-43eb-a491-940d9c1132ba


