### PR TITLE
Remove back buttons on top level sections

### DIFF
--- a/src/app/DeckPage/page.tsx
+++ b/src/app/DeckPage/page.tsx
@@ -146,10 +146,6 @@ const DeckPage: React.FC = () => {
         setDecks(sortedDecks);
     };
 
-    const handleBackButton = () => {
-        router.push('/');
-    };
-
     // Handle successful deck addition
     const handleAddDeckSuccess = (deckData: IDeckData, deckLink: string) => {
         const newDeck: DisplayDeck = {
@@ -551,9 +547,6 @@ const DeckPage: React.FC = () => {
         <>
             <Box sx={styles.header}>
                 <Box sx={styles.sortByContainer}>
-                    <Box sx={styles.titleContainer}>
-                        <PreferenceButton variant={'standard'} buttonFnc={handleBackButton}/>
-                    </Box>
                     <Typography variant={'h3'} sx={styles.sortBy}>Sort by</Typography>
                     <StyledTextField
                         select

--- a/src/app/Terms/page.tsx
+++ b/src/app/Terms/page.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Box, Typography, Divider, List, ListItem, ListItemText } from '@mui/material';
 import { s3ImageURL } from '@/app/_utils/s3Utils';
 import { useRouter } from 'next/navigation';
-import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
 
 const tosBlocks = [
     { type: 'title', text: 'Karabast.net – Terms of Service' },
@@ -84,12 +83,6 @@ const TermsOfService: React.FC = () => {
             pt: { xs: '10px', md: 0 },
             zIndex: 2,
         },
-        backButton: {
-            position: 'absolute' as const,
-            left: '0',
-            top: '-60px',
-            zIndex: 3,
-        },
         brand: {
             fontSize: '3.0em',
             fontWeight: 600,
@@ -139,13 +132,6 @@ const TermsOfService: React.FC = () => {
 
             <Box sx={styles.container}>
                 <Box sx={styles.cardWrapper}>
-                    <Box sx={styles.backButton}>
-                        <PreferenceButton
-                            variant={'standard'}
-                            text="Back"
-                            buttonFnc={handleExit}
-                        />
-                    </Box>
                     <Box sx={styles.card}>
                         <Typography variant="h4" component="h1" gutterBottom>
                             Terms of Service

--- a/src/app/Unimplemented/page.tsx
+++ b/src/app/Unimplemented/page.tsx
@@ -12,7 +12,6 @@ import { cardImageLabel, s3CardImageURL } from '@/app/_utils/s3Utils';
 import { useCardImageLocale } from '@/app/_contexts/CardImageLocale.context';
 import StyledTextField from '@/app/_components/_sharedcomponents/_styledcomponents/StyledTextField';
 import { IPreviewCard } from '@/app/_components/_sharedcomponents/Cards/CardTypes';
-import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
 import { useRouter } from 'next/navigation';
 import { useImageLoadStatus } from '@/app/_hooks/useImageLoadStatus';
 import { CardImageMissingOverlay, cardImageFillSx } from '@/app/_components/_sharedcomponents/Cards/CardImageMissingOverlay';
@@ -190,11 +189,6 @@ const UnimplementedPage = () => {
             marginBottom: '1rem',
             position: 'relative' as const,
         },
-        backButton: {
-            position: 'absolute' as const,
-            left: '10px',
-            height:'100%'
-        },
         cardOuter: {
             width: '100%',
             height: '100%',
@@ -278,13 +272,6 @@ const UnimplementedPage = () => {
         <Box sx={styles.pageContainer}>
             {/* Header with Back button */}
             <Box sx={styles.headerRow}>
-                <Box sx={styles.backButton}>
-                    <PreferenceButton
-                        variant={'standard'}
-                        text="Back"
-                        buttonFnc={handleBackClick}
-                    />
-                </Box>
                 <Typography variant={'h5'} color="white">
                     Unimplemented Cards
                 </Typography>

--- a/src/app/_components/_sharedcomponents/Preferences/PreferencesComponent.tsx
+++ b/src/app/_components/_sharedcomponents/Preferences/PreferencesComponent.tsx
@@ -3,8 +3,6 @@ import { Box, Typography } from '@mui/material';
 import { CloseOutlined } from '@mui/icons-material';
 import VerticalTabs from '@/app/_components/_sharedcomponents/Preferences/_subComponents/VerticalTabs';
 import { IPreferenceProps } from '@/app/_components/_sharedcomponents/Preferences/Preferences.types';
-import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
-import { useRouter } from 'next/navigation';
 
 const PreferencesComponent: React.FC<IPreferenceProps> = ({
     isPreferenceOpen,
@@ -18,12 +16,6 @@ const PreferencesComponent: React.FC<IPreferenceProps> = ({
 }) => {
     const [attemptingClose, setAttemptingClose] = useState(false);
     const [closePreferencesHandler, setClosePreferencesHandler] = useState<() => void>(() => () => undefined);
-
-    const router = useRouter();
-    const attemptBackButton = () => {
-        setClosePreferencesHandler(() => () => router.push('/'));
-        setAttemptingClose(true);
-    };
 
     // ------------------------STYLES------------------------//
     const styles = {
@@ -105,11 +97,6 @@ const PreferencesComponent: React.FC<IPreferenceProps> = ({
         <>
             <Box sx={styles.containerStyle}>
                 <Box sx={styles.overlayStyle}>
-                    {variant === 'homePage' && (
-                        <Box sx={styles.titleContainer}>
-                            <PreferenceButton variant={'standard'} buttonFnc={attemptBackButton}/>
-                        </Box>
-                    )}
                     {title && (
                         <Box sx={styles.headerBox}>
                             <Typography variant="h1">{title}</Typography>


### PR DESCRIPTION
In an attempt to simplify the interface little by little, I believe there's little to no benefit on having back buttons on the different sections of the website (Only top level sections, this doesn't affect pages like Deck details). 

