### PR TITLE
Avoid options to have line breaks by increasing the size on mobile + …

### DIFF
--- a/src/app/_components/_sharedcomponents/Popup/PopupVariant/DropdownPopup.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/PopupVariant/DropdownPopup.tsx
@@ -29,7 +29,7 @@ interface ButtonProps {
 const styles = {
     autocomplete: {
         width: {
-            xs: '80%',
+            xs: '70%',
             md: '50%'
         },
         color: 'white',
@@ -69,7 +69,7 @@ export const DropdownPopupModal = ({ data }: ButtonProps) => {
                     options={data.options}
                     onChange={handleChange}
                     renderInput={(params) => (
-                        <TextField {...params} />
+                        <TextField {...params} type="search" />
                     )}
                     noOptionsText="No results found"
                     sx={styles.autocomplete}

--- a/src/app/_components/_sharedcomponents/Popup/PopupVariant/DropdownPopup.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/PopupVariant/DropdownPopup.tsx
@@ -26,6 +26,22 @@ interface ButtonProps {
     data: DropdownPopup;
 }
 
+const styles = {
+    autocomplete: {
+        width: {
+            xs: '80%',
+            md: '50%'
+        },
+        color: 'white',
+    },
+    autocompletePopper: {
+        '& .MuiAutocomplete-noOptions': {
+            backgroundColor: '#394452',
+            color: 'rgba(255, 255, 255, 0.38)',
+        },
+    }
+}
+
 export const DropdownPopupModal = ({ data }: ButtonProps) => {
     const { sendGameMessage } = useGame();
     const { closePopup } = usePopup();
@@ -49,16 +65,18 @@ export const DropdownPopupModal = ({ data }: ButtonProps) => {
                     <RichText text={data.description} sx={textStyle} component={Typography}/>
                 )}
 
-                <Autocomplete 
+                <Autocomplete
                     options={data.options}
                     onChange={handleChange}
                     renderInput={(params) => (
                         <TextField {...params} />
                     )}
-                    sx={{ width: '50%', color: 'white' }}
+                    noOptionsText="No results found"
+                    sx={styles.autocomplete}
                     slotProps={{ 
                         popupIndicator: { sx: { color: 'white' } },
                         clearIndicator: { sx: { color: 'white' } },
+                        popper: { sx: styles.autocompletePopper },
                     }}
                 />
 


### PR DESCRIPTION
…styles when no results are present

# Problem

Some options break in two lines

<img width="2868" height="1320" alt="596862093-0c0c340f-df15-412a-b82e-cc8121d88349 (1)" src="https://github.com/user-attachments/assets/fcbf321b-5d7a-420e-9bbf-473826ee392e" />

Empty results without styles

<img width="450" alt="IMG_6272" src="https://github.com/user-attachments/assets/bda8cc5c-fdc2-488b-a6ec-8385b1772d85" />

# Fixes

<img height="450" alt="IMG_6270" src="https://github.com/user-attachments/assets/6636bb52-4ef1-4ecc-8f17-ed94de630bf9" />

<img width="450" alt="IMG_6271" src="https://github.com/user-attachments/assets/e0be836f-e487-475a-9068-d3efa04de849" />


