### PR TITLE
#Resolved issue with stats not tracking for karabast decks.

### DIFF
--- a/src/app/_components/Lobby/_subcomponents/DeckSelectionCard/DeckSelectionCard.tsx
+++ b/src/app/_components/Lobby/_subcomponents/DeckSelectionCard/DeckSelectionCard.tsx
@@ -216,17 +216,14 @@ const DeckSelectionCard: React.FC<IDeckSelectionCardProps> = ({
             if (!lobbyIdForRequest) {
                 throw new Error('Lobby id not available for change-deck request');
             }
-            const isSwudbUrl = deckType === 'url' && determineDeckSource(userDeck) === DeckSource.SWUDB;
-            const changeDeckBody = isSwudbUrl
-                ? { swudbLink: userDeck, user: getUserPayload(user) }
-                : { deck: deckData, user: getUserPayload(user) };
+
             const changeDeckResponse = await fetch(
                 `${process.env.NEXT_PUBLIC_ROOT_URL}/api/lobby/${lobbyIdForRequest}/change-deck`,
                 {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     credentials: 'include',
-                    body: JSON.stringify(changeDeckBody),
+                    body: JSON.stringify({ deck: deckData, user: getUserPayload(user) }),
                 }
             );
             if (!changeDeckResponse.ok) {


### PR DESCRIPTION
Resolved issue with stats not tracking for karabast decks.

Scenarios we tried:
both creating a new lobby and for loading a deck within the lobby:
- use deck url and save it
- use deck url, don't save it
- use saved deck
- change deck with "load" to a swudb deck within the lobby.