### PR TITLE
Only get active cosmetics from the BE for rendering on game board

### DIFF
--- a/src/app/GameBoard/page.tsx
+++ b/src/app/GameBoard/page.tsx
@@ -11,20 +11,19 @@ import PopupShell from '../_components/_sharedcomponents/Popup/Popup';
 import PreferencesComponent from '@/app/_components/_sharedcomponents/Preferences/PreferencesComponent';
 import { useRouter } from 'next/navigation';
 import { Bo3SetEndedReason, GamesToWinMode, IBo3SetEndResult, MatchmakingType } from '@/app/_constants/constants';
-import { useCosmetics } from '../_contexts/CosmeticsContext';
+import { s3ImageURL } from '@/app/_utils/s3Utils';
 import { Play } from 'next/font/google';
 import RichText from '../_components/_sharedcomponents/RichText/RichText';
 
 const GameBoard = () => {
     const { getOpponent, connectedPlayer, gameState, lobbyState, isSpectator } = useGame();
     const router = useRouter();
-    const { getBackground } = useCosmetics();
     const sidebarState = localStorage.getItem('sidebarState') !== null ? localStorage.getItem('sidebarState') === 'true' : true;
     const [sidebarOpen, setSidebarOpen] = useState(sidebarState);
     const [isPreferenceOpen, setPreferenceOpen] = useState(false);
     const [userClosedWinScreen, setUserClosedWinScreen] = useState(false);
     const user = gameState?.players[connectedPlayer]?.user;
-    const background = getBackground(isSpectator ? null : user?.cosmetics?.background ?? null);
+    const backgroundPath = (isSpectator ? undefined : user?.cosmetics?.background?.path) ?? s3ImageURL('ui/board-background-1.webp');
     // const playMatsDisabled = isSpectator ? true : user?.cosmetics?.disablePlaymats ?? true;
     // const myPlaymatId = !playMatsDisabled ? user?.cosmetics?.playmat : 'none';
     // const myPlaymat = myPlaymatId && myPlaymatId !== 'none' ? getPlaymat(myPlaymatId) : null;
@@ -108,7 +107,7 @@ const GameBoard = () => {
             transition: 'padding-right 0.3s ease-in-out',
             height: '100dvh',
             position: 'relative',
-            backgroundImage: `url(${background.path}?v=2)`,
+            backgroundImage: `url(${backgroundPath}?v=2)`,
             '-webkit-touch-callout': 'none', /* Disables the long-press menu on iOS */
             '-webkit-user-select': 'none',   /* Prevents image selection */
             userSelect: 'none',

--- a/src/app/_components/Gameboard/OpponentCardTray/OpponentCardTray.tsx
+++ b/src/app/_components/Gameboard/OpponentCardTray/OpponentCardTray.tsx
@@ -37,7 +37,7 @@ const OpponentCardTray: React.FC<IOpponentCardTrayProps> = ({ trayPlayer, prefer
 
     const activePlayer = gameState.players[connectedPlayer].isActionPhaseActivePlayer;
     const phase = gameState.phase;
-    const opponentsCardback = isSpectator ? undefined : gameState?.players[getOpponent(connectedPlayer)].user?.cosmetics?.cardback;
+    const opponentsCardbackPath = isSpectator ? undefined : gameState?.players[getOpponent(connectedPlayer)].user?.cosmetics?.cardback?.path;
 
     const hasLastPlayedCard = !!gameState.clientUIProperties?.lastPlayedCard
     const lastPlayedCardUrl = hasLastPlayedCard ? `url(${s3CardImageURL({ setId: gameState.clientUIProperties.lastPlayedCard, type: '', id: '' }, locale)})` : 'none';
@@ -188,7 +188,7 @@ const OpponentCardTray: React.FC<IOpponentCardTrayProps> = ({ trayPlayer, prefer
                     ...styles.leftColumn,
                 }}
             >
-                <DeckDiscard trayPlayer={trayPlayer} cardback={opponentsCardback} />
+                <DeckDiscard trayPlayer={trayPlayer} cardback={opponentsCardbackPath} />
                 <Box sx={styles.creditsResourcesStack}>
                     <Credits trayPlayer={trayPlayer} />
                     <Resources trayPlayer={trayPlayer}/>
@@ -208,7 +208,7 @@ const OpponentCardTray: React.FC<IOpponentCardTrayProps> = ({ trayPlayer, prefer
                         maxCardOverlapPercent={0.95}
                         scrollbarEnabled={false}
                         cards={gameState?.players[getOpponent(connectedPlayer)].cardPiles['hand'] || []}
-                        cardback={opponentsCardback} />
+                        cardback={opponentsCardbackPath} />
                 </Box>
                 <Box sx={ styles.opponentTurnAura} />
             </Grid>

--- a/src/app/_components/Gameboard/PlayerCardTray/PlayerCardTray.tsx
+++ b/src/app/_components/Gameboard/PlayerCardTray/PlayerCardTray.tsx
@@ -18,7 +18,7 @@ const PlayerCardTray: React.FC<IPlayerCardTrayProps> = ({ trayPlayer, toggleSide
     const { isPortrait } = useScreenOrientation();
 
     const activePlayer = gameState.players[connectedPlayer].isActionPhaseActivePlayer;
-    const connectedUserCardback = isSpectator ? undefined : gameState?.players[connectedPlayer].user?.cosmetics?.cardback;
+    const connectedUserCardbackPath = isSpectator ? undefined : gameState?.players[connectedPlayer].user?.cosmetics?.cardback?.path;
     const phase = gameState.phase;
 
     const styles = {
@@ -109,7 +109,7 @@ const PlayerCardTray: React.FC<IPlayerCardTrayProps> = ({ trayPlayer, toggleSide
                 size={{ xs: 3, md: 3 }}
                 sx={styles.leftColumnStyle}
             >
-                <DeckDiscard trayPlayer={trayPlayer} cardback={connectedUserCardback} />
+                <DeckDiscard trayPlayer={trayPlayer} cardback={connectedUserCardbackPath} />
                 <Box sx={styles.creditsResourcesStack}>
                     <Credits trayPlayer={trayPlayer} />
                     <Resources trayPlayer={trayPlayer} />

--- a/src/app/_components/Gameboard/_subcomponents/PlayerTray/DeckDiscard.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/PlayerTray/DeckDiscard.tsx
@@ -8,13 +8,11 @@ import { useCardImageLocale } from '@/app/_contexts/CardImageLocale.context';
 import { PopupSource } from '@/app/_components/_sharedcomponents/Popup/Popup.types';
 import { debugBorder } from '@/app/_utils/debug';
 import useScreenOrientation from '@/app/_utils/useScreenOrientation';
-import { useCosmetics } from '@/app/_contexts/CosmeticsContext';
 
 const DeckDiscard: React.FC<IDeckDiscardProps> = ({ trayPlayer, cardback }) => {
     const { gameState, connectedPlayer } = useGame();
     const { togglePopup, popups } = usePopup();
     const { isPortrait } = useScreenOrientation();
-    const { getCardback } = useCosmetics();
     const locale = useCardImageLocale();
     // Refs for individual card containers
     const discardRef = useRef<HTMLDivElement>(null);
@@ -212,7 +210,7 @@ const DeckDiscard: React.FC<IDeckDiscardProps> = ({ trayPlayer, cardback }) => {
                 backgroundColor: 'black',
                 backgroundPosition: 'center',
                 backgroundSize: canSeeTopCard ? 'cover' : '100%',
-                backgroundImage: canSeeTopCard ? topDeckCardUrl : (cardback ? `url(${getCardback(cardback).path})` : 'url(\'/card-back.png\')'),
+                backgroundImage: canSeeTopCard ? topDeckCardUrl : (cardback ? `url(${cardback})` : 'url(\'/card-back.png\')'),
                 backgroundRepeat: 'no-repeat',
                 display: 'flex',
                 alignItems: 'center',

--- a/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
@@ -13,7 +13,6 @@ import { CardImageMissingOverlay, cardImageFillSx } from './CardImageMissingOver
 import { useLeaderCardFlipPreview } from '@/app/_hooks/useLeaderPreviewFlip';
 import { useLongPress } from '@/app/_hooks/useLongPress';
 import { DistributionEntry } from '@/app/_hooks/useDistributionPrompt';
-import { useCosmetics } from '@/app/_contexts/CosmeticsContext';
 import { ZoneName } from '@/app/_constants/constants';
 
 import { DamageCounterToken } from '../_styledcomponents/damageCounterToken';
@@ -64,7 +63,6 @@ const GameCard: React.FC<IGameCardProps> = ({
 }) => {
     const { sendGameMessage, connectedPlayer, getConnectedPlayerPrompt, distributionPromptData, gameState, isSpectator, hoveredChatCard } = useGame();
     const { clearPopups } = usePopup();
-    const { getCardback } = useCosmetics();
     const locale = useCardImageLocale();
 
     const distributeHealing = gameState?.players[connectedPlayer]?.promptState.distributeAmongTargets?.type === 'distributeHealing';
@@ -178,7 +176,7 @@ const GameCard: React.FC<IGameCardProps> = ({
 
     // Compute card image URL + load status before any early return so hooks
     // are called in a stable order.
-    const cardbackPath = getCardback(cardback).path;
+    const cardbackPath = cardback;
     const styledCardUrl = card
         ? s3CardImageURL(
             { ...card, setId: card.clonedCardId ?? card.setId },

--- a/src/app/_components/_sharedcomponents/Preferences/Preferences.types.ts
+++ b/src/app/_components/_sharedcomponents/Preferences/Preferences.types.ts
@@ -64,17 +64,22 @@ export enum RegisteredCosmeticType {
     // Playmat = 'playmat',
 }
 
-export interface IRegisteredCosmeticOption {
+export interface ICosmeticEntity {
     id: string;
     title: string;
     type: RegisteredCosmeticType;
     path: string;
 }
 
+export interface IActiveCosmetics {
+    cardback: ICosmeticEntity;
+    background: ICosmeticEntity;
+}
+
 export interface IRegisteredCosmetics {
-    cardbacks: IRegisteredCosmeticOption[];
-    backgrounds: IRegisteredCosmeticOption[];
-    // playmats: IRegisteredCosmeticOption[];
+    cardbacks: ICosmeticEntity[];
+    backgrounds: ICosmeticEntity[];
+    // playmats: ICosmeticEntity[];
 }
 
 // constants

--- a/src/app/_components/_sharedcomponents/Preferences/PreferencesSubElementVariants/CosmeticsTab.tsx
+++ b/src/app/_components/_sharedcomponents/Preferences/PreferencesSubElementVariants/CosmeticsTab.tsx
@@ -30,9 +30,14 @@ function CosmeticsTab() {
                 /* setSelectedPlaymat(cosmetics.playmat ?? 'none');
                 setDisablePlaymats(cosmetics.disablePlaymats ?? false);*/
             }
-            fetchCosmetics();
         }
     }, [user]);
+
+    useEffect(() => {
+        if (user?.id) {
+            fetchCosmetics();
+        }
+    }, [user?.id, fetchCosmetics]);
 
     const onCardbackClick = async (is: string) => {
         try {

--- a/src/app/_components/_sharedcomponents/Preferences/PreferencesSubElementVariants/CosmeticsTab.tsx
+++ b/src/app/_components/_sharedcomponents/Preferences/PreferencesSubElementVariants/CosmeticsTab.tsx
@@ -8,7 +8,7 @@ import { Accordion, AccordionSummary, AccordionDetails, Typography, Box, FormCon
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { useCosmetics } from '@/app/_contexts/CosmeticsContext';
 
-import { IRegisteredCosmeticOption } from '../Preferences.types';
+import { ICosmeticEntity } from '../Preferences.types';
 
 function CosmeticsTab() {
     const { user, updateUserPreferences } = useUser();
@@ -104,7 +104,7 @@ function CosmeticsTab() {
         setExpandedAccordion(isExpanded ? panel : '');
     };
 
-    const filterSelectableCosmetics = (cosmeticsList: IRegisteredCosmeticOption[]): IRegisteredCosmeticOption[] => {
+    const filterSelectableCosmetics = (cosmeticsList: ICosmeticEntity[]): ICosmeticEntity[] => {
         if (isContributor) {
             return cosmeticsList;
         }
@@ -112,7 +112,7 @@ function CosmeticsTab() {
     };
 
     // Utility function to sort cosmetics by title, ignoring articles
-    const sortCosmeticsByTitle = (cosmetics: IRegisteredCosmeticOption[]) => {
+    const sortCosmeticsByTitle = (cosmetics: ICosmeticEntity[]) => {
         return [...cosmetics].sort((a, b) => {
             // Always put "Default" first
             if (a.title === 'Default') return -1;
@@ -131,7 +131,7 @@ function CosmeticsTab() {
     };
     // Create playmats list with 'None' option
     /* const getPlaymatOptions = () => {
-        const noneOption: IRegisteredCosmeticOption = {
+        const noneOption: ICosmeticEntity = {
             id: 'none',
             title: 'None',
             type: RegisteredCosmeticType.Playmat,

--- a/src/app/_contexts/CosmeticsContext.tsx
+++ b/src/app/_contexts/CosmeticsContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React from 'react';
 import {
-    IRegisteredCosmeticOption,
+    ICosmeticEntity,
     IRegisteredCosmetics,
     RegisteredCosmeticType
 } from '../_components/_sharedcomponents/Preferences/Preferences.types';
@@ -10,9 +10,9 @@ import { ServerApiService } from '../_services/ServerApiService';
 interface CosmeticsContextProps {
     cosmetics: IRegisteredCosmetics;
     setCosmetics: React.Dispatch<React.SetStateAction<IRegisteredCosmetics>>;
-    getCardback: (id?: string) => IRegisteredCosmeticOption;
-    getBackground: (id?: string) => IRegisteredCosmeticOption;
-    // getPlaymat: (id?: string) => IRegisteredCosmeticOption;
+    getCardback: (id?: string) => ICosmeticEntity;
+    getBackground: (id?: string) => ICosmeticEntity;
+    // getPlaymat: (id?: string) => ICosmeticEntity;
     fetchCosmetics: () => void;
     isContributor: boolean;
 }
@@ -38,7 +38,7 @@ export const CosmeticsProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
     const [cosmetics, setCosmetics] = React.useState<IRegisteredCosmetics>(defaultCosmetics);
     const [isContributor, setIsContributor] = React.useState<boolean>(false);
-    const getCosmeticDefault = (type: RegisteredCosmeticType): IRegisteredCosmeticOption => {
+    const getCosmeticDefault = (type: RegisteredCosmeticType): ICosmeticEntity => {
         switch(type) {
             case RegisteredCosmeticType.Cardback:
                 return cosmetics.cardbacks.find((cb) => cb.title === 'Default')!;
@@ -90,10 +90,6 @@ export const CosmeticsProvider: React.FC<{ children: React.ReactNode }> = ({
             return acc;
         }, { cardbacks: [], backgrounds: [] }));
     };
-
-    React.useEffect(() => {
-        fetchCosmeticsAsync();
-    }, []);
 
     return (
         <CosmeticsContext.Provider value={{ cosmetics, setCosmetics,

--- a/src/app/_contexts/CosmeticsContext.tsx
+++ b/src/app/_contexts/CosmeticsContext.tsx
@@ -71,7 +71,7 @@ export const CosmeticsProvider: React.FC<{ children: React.ReactNode }> = ({
         return cosmetics.playmats.find((pm) => pm.id === id) || getCosmeticDefault(RegisteredCosmeticType.Playmat);
     }*/
 
-    const fetchCosmeticsAsync = async () => {
+    const fetchCosmeticsAsync = React.useCallback(async () => {
         const data = await ServerApiService.getCosmeticsAsync();
         setIsContributor(data.isContributor);
         setCosmetics(data.cosmetics.reduce((acc: IRegisteredCosmetics, cosmetic) => {
@@ -89,7 +89,7 @@ export const CosmeticsProvider: React.FC<{ children: React.ReactNode }> = ({
             }
             return acc;
         }, { cardbacks: [], backgrounds: [] }));
-    };
+    }, []);
 
     return (
         <CosmeticsContext.Provider value={{ cosmetics, setCosmetics,

--- a/src/app/_contexts/User.context.tsx
+++ b/src/app/_contexts/User.context.tsx
@@ -70,6 +70,7 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({
                         showWelcomeMessage: serverUser.showWelcomeMessage,
                         authenticated: true,
                         preferences: serverUser.preferences,
+                        activeCosmetics: serverUser.activeCosmetics,
                         needsUsernameChange: serverUser.needsUsernameChange,
                         mustRequestUsernameChange: serverUser.mustRequestUsernameChange,
                         reportingDisabled: serverUser.reportingDisabled,

--- a/src/app/_contexts/UserTypes.ts
+++ b/src/app/_contexts/UserTypes.ts
@@ -1,4 +1,5 @@
 import type { CardImageLocale } from '@/app/_utils/s3Utils';
+import type { IActiveCosmetics } from '@/app/_components/_sharedcomponents/Preferences/Preferences.types';
 
 export interface IUser extends IGetUser{
     email?: string;
@@ -43,6 +44,7 @@ export interface IGetUser {
     username: string;
     showWelcomeMessage: boolean;
     preferences: IPreferences,
+    activeCosmetics?: IActiveCosmetics,
     needsUsernameChange: boolean;
     mustRequestUsernameChange?: ModerationFieldState | null;
     reportingDisabled?: ModerationFieldState | null;

--- a/src/app/_services/ServerApiService.ts
+++ b/src/app/_services/ServerApiService.ts
@@ -1,6 +1,6 @@
 import {
     IFindUserResponse, IModActionResponse,
-    IRegisteredCosmeticOption
+    ICosmeticEntity
 } from '../_components/_sharedcomponents/Preferences/Preferences.types';
 
 
@@ -37,10 +37,10 @@ export class ServerApiService {
     }
 
     // Cosmetics API methods
-    public static async getCosmeticsAsync(): Promise<{ cosmetics: IRegisteredCosmeticOption[], isContributor: boolean }> {
+    public static async getCosmeticsAsync(): Promise<{ cosmetics: ICosmeticEntity[], isContributor: boolean }> {
         const response = await this.fetchWithErrorHandling<{
             success: boolean;
-            cosmetics: IRegisteredCosmeticOption[];
+            cosmetics: ICosmeticEntity[];
             count: number;
             isContributor: boolean;
         }>(`${this.baseUrl}/api/cosmetics`);
@@ -51,11 +51,11 @@ export class ServerApiService {
         };
     }
 
-    public static async saveCosmeticAsync(cosmetic: IRegisteredCosmeticOption, cookies?: string): Promise<IRegisteredCosmeticOption> {
+    public static async saveCosmeticAsync(cosmetic: ICosmeticEntity, cookies?: string): Promise<ICosmeticEntity> {
         const response = await this.fetchWithErrorHandling<{
             success: boolean;
             message: string;
-            cosmetic: IRegisteredCosmeticOption;
+            cosmetic: ICosmeticEntity;
         }>(`${this.baseUrl}/api/cosmetics`, {
             method: 'POST',
             headers: {

--- a/src/app/api/admin/cosmetics/upload-file/route.ts
+++ b/src/app/api/admin/cosmetics/upload-file/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getS3ServiceAsync } from '@/app/_services/S3Service';
-import { IRegisteredCosmeticOption, RegisteredCosmeticType } from '@/app/_components/_sharedcomponents/Preferences/Preferences.types';
+import { ICosmeticEntity, RegisteredCosmeticType } from '@/app/_components/_sharedcomponents/Preferences/Preferences.types';
 import { withAdminAuth } from '@/app/_utils/AdminAuth';
 import { AdminRole } from '@/app/_contexts/UserTypes';
 import { ServerApiService } from '@/app/_services/ServerApiService';
@@ -85,7 +85,7 @@ export const POST = withAdminAuth(AdminRole.Moderator, async (request: NextReque
         const s3Url = await s3Service.uploadFile(s3Key, fileBuffer, 'image/webp');
 
         // Create cosmetic metadata
-        const cosmeticData: IRegisteredCosmeticOption = {
+        const cosmeticData: ICosmeticEntity = {
             id: cosmeticId,
             title: cosmeticTitle,
             type: cosmeticType as RegisteredCosmeticType,

--- a/src/app/mod/subpages/CosmeticsManagerTab.tsx
+++ b/src/app/mod/subpages/CosmeticsManagerTab.tsx
@@ -20,7 +20,7 @@ import {
 import Image from 'next/image';
 import StyledTextField from '@/app/_components/_sharedcomponents/_styledcomponents/StyledTextField';
 import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
-import { IRegisteredCosmeticOption, RegisteredCosmeticType } from '@/app/_components/_sharedcomponents/Preferences/Preferences.types';
+import { ICosmeticEntity, RegisteredCosmeticType } from '@/app/_components/_sharedcomponents/Preferences/Preferences.types';
 import { v4 as uuidv4 } from 'uuid';
 import { useCosmetics } from '@/app/_contexts/CosmeticsContext';
 import { ServerApiService } from '@/app/_services/ServerApiService';
@@ -40,7 +40,7 @@ const isDev = process.env.NODE_ENV === 'development';
 
 const CosmeticsManagerTab: React.FC = () => {
     const { cosmetics, setCosmetics, fetchCosmetics } = useCosmetics();
-    const [filteredCosmetics, setFilteredCosmetics] = useState<IRegisteredCosmeticOption[]>([]);
+    const [filteredCosmetics, setFilteredCosmetics] = useState<ICosmeticEntity[]>([]);
     const [availableTypes, setAvailableTypes] = useState<string[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -90,14 +90,14 @@ const CosmeticsManagerTab: React.FC = () => {
         let results = allCosmetics;
 
         if (typeFilter !== 'All') {
-            results = results.filter((cosmetic: IRegisteredCosmeticOption) =>
+            results = results.filter((cosmetic: ICosmeticEntity) =>
                 cosmetic.type.toLowerCase() === typeFilter.toLowerCase()
             );
         }
 
         if (searchQuery.trim() !== '') {
             const query = searchQuery.toLowerCase();
-            results = results.filter((cosmetic: IRegisteredCosmeticOption) => {
+            results = results.filter((cosmetic: ICosmeticEntity) => {
                 const title = cosmetic.title?.toLowerCase() || '';
                 const id = cosmetic.id?.toLowerCase() || '';
                 return title.includes(query) || id.includes(query);
@@ -109,7 +109,7 @@ const CosmeticsManagerTab: React.FC = () => {
 
     useEffect(() => {
         if (allCosmetics.length > 0) {
-            const types = allCosmetics.reduce((acc: string[], cosmetic: IRegisteredCosmeticOption) => {
+            const types = allCosmetics.reduce((acc: string[], cosmetic: ICosmeticEntity) => {
                 const type = cosmetic.type.charAt(0).toUpperCase() + cosmetic.type.slice(1);
                 if (!acc.includes(type)) {
                     acc.push(type);
@@ -528,7 +528,7 @@ const CosmeticsManagerTab: React.FC = () => {
             <Box sx={styles.cardOuter}>
                 <Card sx={styles.cardStyle}>
                     <Box sx={styles.mainContainerStyle}>
-                        {filteredCosmetics.map((cosmetic: IRegisteredCosmeticOption) => (
+                        {filteredCosmetics.map((cosmetic: ICosmeticEntity) => (
                             <Box sx={styles.cosmeticContainer} key={cosmetic.id}>
                                 <Box
                                     sx={{

--- a/src/app/quickGame/page.tsx
+++ b/src/app/quickGame/page.tsx
@@ -6,7 +6,7 @@ import FoundGame from '@/app/_components/QuickGame/FoundGame/FoundGame';
 import { useGame } from '@/app/_contexts/Game.context';
 import SearchingForGame from '@/app/_components/QuickGame/SearchingForGame/SearchingForGame';
 import { useRouter } from 'next/navigation';
-import { useCosmetics } from '../_contexts/CosmeticsContext';
+import { s3ImageURL } from '@/app/_utils/s3Utils';
 import { useUser } from '../_contexts/User.context';
 
 const QuickGame: React.FC = () => {
@@ -16,9 +16,8 @@ const QuickGame: React.FC = () => {
         sendMessage('manualDisconnect');
         router.push('/');
     }
-    const { getBackground } = useCosmetics();
     const { user } = useUser();
-    const background = getBackground(user?.preferences.cosmetics?.background);
+    const backgroundPath = user?.activeCosmetics?.background?.path ?? s3ImageURL('ui/board-background-1.webp');
 
     useEffect(() => {
         if (gameState) {
@@ -34,7 +33,7 @@ const QuickGame: React.FC = () => {
         containerStyle: {
             height: '100vh',
             overflow: 'hidden',
-            backgroundImage: `url(${background?.path}?v=2)`,
+            backgroundImage: `url(${backgroundPath}?v=2)`,
             backgroundSize: 'cover',
             backgroundPosition: 'center',
         },


### PR DESCRIPTION
BE PR: https://github.com/SWU-Karabast/forceteki/pull/2605

Currently, the BE sends the entire list of all available cosmetic options (cardbacks, backgrounds) to the FE when a user first hits the site. From this, the FE chooses the active customization options for the user based on their account settings.

This is incredibly inefficient from a data perspective, since we should be sending just the customizations that are active for the user instead of the entire catalog. This PR streamlines the data contract so that we can do exactly that.

To test these changes, use the wiki instructions here: https://github.com/SWU-Karabast/forceteki/wiki/Local-S3-Setup