### PR TITLE
Disable preview cache setting for ASH card images

### DIFF
--- a/images-scripts/process_cards.py
+++ b/images-scripts/process_cards.py
@@ -158,7 +158,7 @@ PER_SET_LANDSCAPE_DOUBLE_LEADERS: dict[str, set[int]] = {
 # via S3 CopyObject (no body re-upload, no data-transfer cost).
 CACHE_CONTROL_DEFAULT = "public, max-age=31536000, immutable"
 CACHE_CONTROL_PREVIEW = "public, max-age=604800, immutable"
-PREVIEW_SETS: set[str] = {"ASH"}
+PREVIEW_SETS: set[str] = {}
 
 
 def cache_control_for(set_code: str) -> str:


### PR DESCRIPTION
The image sets for ASH have been stable for a couple weeks now, so presumably all the images are in their final form and we don't expect any more changes or improvements. This change to the image script updates the cache header rules for ASH images so that they will now be cached locally for a year instead of a week.