### PR TITLE
Allow to flip leader cards on mobile

### DIFF
--- a/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/GameCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Box, Popover, PopoverOrigin, Tooltip, Typography } from '@mui/material';
+import { Box, IconButton, Popover, PopoverOrigin, Tooltip, Typography } from '@mui/material';
+import ThreeSixty from '@mui/icons-material/ThreeSixty';
 import Grid from '@mui/material/Grid';
 import { CardStyle, ICardData, IGameCardProps } from './CardTypes';
 import CardValueAdjuster from './CardValueAdjuster';
@@ -90,6 +91,7 @@ const GameCard: React.FC<IGameCardProps> = ({
         aspectRatio,
         width,
         isFlipped,
+        toggleFlip,
     } = useLeaderCardFlipPreview({
         anchorElement,
         cardId: anchorElement?.getAttribute('data-card-id') || undefined,
@@ -110,10 +112,7 @@ const GameCard: React.FC<IGameCardProps> = ({
             setAnchorElement(target);
             setPreviewImage(`url(${imageUrl})`);
         },
-        onRelease: () => {
-            setAnchorElement(null);
-            setPreviewImage(null);
-        },
+        onRelease: () => undefined,
     });
 
     const isStolen = React.useMemo(() => {
@@ -147,12 +146,12 @@ const GameCard: React.FC<IGameCardProps> = ({
         setPreviewImage(null);
     };
 
-    // Tap-anywhere-to-close fallback for touch devices
+    // Keep touch previews open until the next interaction anywhere on the screen.
     React.useEffect(() => {
         if (!open || !isTouchDevice) return;
-        const onTouchStart = () => handlePreviewClose();
-        document.addEventListener('touchstart', onTouchStart);
-        return () => document.removeEventListener('touchstart', onTouchStart);
+        const onPointerDown = () => handlePreviewClose();
+        document.addEventListener('pointerdown', onPointerDown);
+        return () => document.removeEventListener('pointerdown', onPointerDown);
     }, [open, isTouchDevice]);
 
 
@@ -622,6 +621,23 @@ const GameCard: React.FC<IGameCardProps> = ({
             aspectRatio,
             width,
         },
+        mobileFlipButton: {
+            position: 'absolute',
+            top: '0.35rem',
+            right: '0.35rem',
+            zIndex: 2,
+            width: '3.25rem',
+            height: '3.25rem',
+            color: 'white',
+            backgroundColor: 'rgba(3, 12, 19, 0.72)',
+            border: '1px solid rgba(255, 255, 255, 0.38)',
+            borderRadius: '999px',
+            boxShadow: '0 2px 6px rgba(0, 0, 0, 0.55)',
+            transition: 'opacity 140ms ease, background-color 140ms ease',
+            '&:hover': {
+                backgroundColor: 'rgba(3, 12, 19, 0.9)',
+            },
+        },
         attackIcon: {
             position: 'absolute',
             backgroundImage: 'url(/Attacking.svg)',
@@ -787,7 +803,7 @@ const GameCard: React.FC<IGameCardProps> = ({
 
             <Popover
                 id="mouse-over-popover"
-                sx={{ pointerEvents: 'none' }}
+                sx={{ pointerEvents: isTouchDevice ? 'auto' : 'none' }}
                 open={open}
                 anchorEl={anchorElement}
                 onClose={handlePreviewClose}
@@ -795,7 +811,22 @@ const GameCard: React.FC<IGameCardProps> = ({
                 slotProps={{ paper: { sx: { backgroundColor: 'transparent', boxShadow: 'none' }, tabIndex: -1 } }}
                 {...popoverConfig}
             >
-                <Box sx={{ ...styles.cardPreview, backgroundImage: previewImage }} />
+                <Box sx={{ position: 'relative' }}>
+                    <Box sx={{ ...styles.cardPreview, backgroundImage: previewImage }} />
+                    {isPreviewingLeaderCard && isTouchDevice && (
+                        <IconButton
+                            aria-label="Flip leader card"
+                            sx={styles.mobileFlipButton}
+                            onPointerDown={(event) => event.stopPropagation()}
+                            onClick={(event) => {
+                                event.stopPropagation();
+                                toggleFlip();
+                            }}
+                        >
+                            <ThreeSixty fontSize="medium" />
+                        </IconButton>
+                    )}
+                </Box>
                 {isPreviewingLeaderCard && !isTouchDevice && !isFlipped && (
                     <Typography variant={'body1'} sx={styles.ctrlText}
                     >CTRL: View Flipside</Typography>

--- a/src/app/_components/_sharedcomponents/Cards/LeaderBaseCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/LeaderBaseCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Box, Popover, Typography, useMediaQuery } from '@mui/material';
+import { Box, IconButton, Popover, Typography, useMediaQuery } from '@mui/material';
+import ThreeSixty from '@mui/icons-material/ThreeSixty';
 import { CardStyle, ICardData, ILeaderBaseCardProps, LeaderBaseCardStyle } from './CardTypes';
 import { useGame } from '@/app/_contexts/Game.context';
 import { cardImageLabel, s3CardImageURL, s3TokenImageURL } from '@/app/_utils/s3Utils';
@@ -57,22 +58,19 @@ const LeaderBaseCard: React.FC<ILeaderBaseCardProps> = ({
             setAnchorElement(target);
             setPreviewImage(`url(${imageUrl})`);
         },
-        onRelease: () => {
-            setAnchorElement(null);
-            setPreviewImage(null);
-        },
+        onRelease: () => undefined,
     });
 
-    // Tap-anywhere-to-close fallback for touch devices
+    // Keep touch previews open until the next interaction anywhere on the screen.
     React.useEffect(() => {
         if (!open || !isTouchDevice) return;
-        const onTouchStart = () => {
+        const onPointerDown = () => {
             clearTimeout(hoverTimeout.current);
             setAnchorElement(null);
             setPreviewImage(null);
         };
-        document.addEventListener('touchstart', onTouchStart);
-        return () => document.removeEventListener('touchstart', onTouchStart);
+        document.addEventListener('pointerdown', onPointerDown);
+        return () => document.removeEventListener('pointerdown', onPointerDown);
     }, [open, isTouchDevice]);
 
     // Compute card image URL + load status before any early return so hooks
@@ -367,6 +365,23 @@ const LeaderBaseCard: React.FC<ILeaderBaseCardProps> = ({
             aspectRatio: aspectRatio,
             width: width,
         },
+        mobileFlipButton: {
+            position: 'absolute',
+            top: '0.35rem',
+            right: '0.35rem',
+            zIndex: 2,
+            width: '3.25rem',
+            height: '3.25rem',
+            color: 'white',
+            backgroundColor: 'rgba(3, 12, 19, 0.72)',
+            border: '1px solid rgba(255, 255, 255, 0.38)',
+            borderRadius: '999px',
+            boxShadow: '0 2px 6px rgba(0, 0, 0, 0.55)',
+            transition: 'opacity 140ms ease, background-color 140ms ease',
+            '&:hover': {
+                backgroundColor: 'rgba(3, 12, 19, 0.9)',
+            },
+        },
         defendIcon: {
             position: 'absolute',
             backgroundImage:  'url(/defending.svg)',
@@ -550,7 +565,7 @@ const LeaderBaseCard: React.FC<ILeaderBaseCardProps> = ({
 
                 <Popover
                     id="mouse-over-popover"
-                    sx={{ pointerEvents: 'none' }}
+                    sx={{ pointerEvents: isTouchDevice ? 'auto' : 'none' }}
                     open={open}
                     anchorEl={anchorElement}
                     anchorOrigin={isMobilePortrait ? {
@@ -571,9 +586,23 @@ const LeaderBaseCard: React.FC<ILeaderBaseCardProps> = ({
                     disableRestoreFocus
                     slotProps={{ paper: { sx: { backgroundColor: 'transparent', boxShadow: 'none' } } }}
                 >
-                    <Box sx={{
-                        ...styles.cardPreview,backgroundImage: previewImage
-                    }} >
+                    <Box sx={{ position: 'relative' }}>
+                        <Box sx={{
+                            ...styles.cardPreview,backgroundImage: previewImage
+                        }} />
+                        {isLeader && isTouchDevice && (
+                            <IconButton
+                                aria-label="Flip leader card"
+                                sx={styles.mobileFlipButton}
+                                onPointerDown={(event) => event.stopPropagation()}
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    leaderCardFlipPreview.toggleFlip();
+                                }}
+                            >
+                                <ThreeSixty fontSize="medium" />
+                            </IconButton>
+                        )}
                     </Box>
                     {isLeader && !isTouchDevice && !leaderCardFlipPreview.isFlipped && (
                         <Typography variant={'body1'} sx={styles.ctrlText}

--- a/src/app/_hooks/useLeaderPreviewFlip.ts
+++ b/src/app/_hooks/useLeaderPreviewFlip.ts
@@ -8,6 +8,7 @@ interface UseLeaderCardFlipPreviewReturn {
     aspectRatio: string;
     width: string;
     isFlipped: boolean;
+    toggleFlip: () => void;
 }
 
 interface UseLeaderCardFlipPreviewParams {
@@ -41,6 +42,8 @@ export function useLeaderCardFlipPreview(params: UseLeaderCardFlipPreviewParams)
     } = params;
 
     const locale = useCardImageLocale();
+    const [frontPreviewImage, setFrontPreviewImage] = useState<string | null>(null);
+    const [backPreviewImage, setBackPreviewImage] = useState<string | null>(null);
 
     // set starting side internally (handles Chancellor Palpatine special case)
     const startingSide = useMemo(() => {
@@ -127,7 +130,11 @@ export function useLeaderCardFlipPreview(params: UseLeaderCardFlipPreviewParams)
                 setPreviewImage(`url(${frontURL})`);
             }
         };
-        setPreviewImage(`url(${frontURL})`);
+        const frontImage = `url(${frontURL})`;
+        const backImage = `url(${backURL})`;
+        setFrontPreviewImage(frontImage);
+        setBackPreviewImage(backImage);
+        setPreviewImage(frontImage);
         setInternalIsCtrl(false);
         window.addEventListener('keydown', handleKeyDown);
         window.addEventListener('keyup', handleKeyUp);
@@ -135,13 +142,25 @@ export function useLeaderCardFlipPreview(params: UseLeaderCardFlipPreviewParams)
         return () => {
             window.removeEventListener('keydown', handleKeyDown);
             window.removeEventListener('keyup', handleKeyUp);
+            setFrontPreviewImage(null);
+            setBackPreviewImage(null);
         };
     }, [anchorElement, backCardStyle, cardId, frontCardStyle, isLeader, locale, setPreviewImage, startingSide]);
+
+    const toggleFlip = () => {
+        if (!frontPreviewImage || !backPreviewImage) return;
+
+        setInternalIsCtrl((isFlipped) => {
+            setPreviewImage(isFlipped ? frontPreviewImage : backPreviewImage);
+            return !isFlipped;
+        });
+    };
 
     return {
         // Calculated style properties
         aspectRatio: styleSetter.aspectRatio,
         width: styleSetter.width,
         isFlipped: internalIsCtrl,
+        toggleFlip,
     };
 }


### PR DESCRIPTION
## Summary

It's not possible to flip a leader card on mobile. I added a flip button on the corner but in order to work, popover shouldn't close on touch release. New behavior closes the popover after the next tap.

Changes:

- Keep mobile longpress card previews open after touch release until the next tap or click anywhere on the screen.
- Add a mobile-only leader preview flip button using the same styling as the trigger action card preview control.
- Reuse the existing leader preview flip logic so desktop CTRL behavior remains unchanged.

## UI


https://github.com/user-attachments/assets/6813801c-82cf-4944-aa6f-cdca5172d351



Desktop remains unchanged
