### PR TITLE
Move prompt text to board and avoid absolute positioning

### DIFF
--- a/src/app/GameBoard/page.tsx
+++ b/src/app/GameBoard/page.tsx
@@ -13,7 +13,6 @@ import { useRouter } from 'next/navigation';
 import { Bo3SetEndedReason, GamesToWinMode, IBo3SetEndResult, MatchmakingType } from '@/app/_constants/constants';
 import { s3ImageURL } from '@/app/_utils/s3Utils';
 import { Play } from 'next/font/google';
-import RichText from '../_components/_sharedcomponents/RichText/RichText';
 
 const GameBoard = () => {
     const { getOpponent, connectedPlayer, gameState, lobbyState, isSpectator } = useGame();
@@ -97,8 +96,6 @@ const GameBoard = () => {
         return null;
     }
 
-    const promptTitle = gameState?.players[connectedPlayer].promptState.promptTitle;
-    const menuTitle = gameState?.players[connectedPlayer].promptState.menuTitle;
     // ----------------------Styles-----------------------------//
     const styles = {
         mainBoxStyle: {
@@ -116,44 +113,7 @@ const GameBoard = () => {
             display: 'flex',
             flexDirection: 'column',
         },
-        centralPromptContainer: {
-            position: 'absolute',
-            top: '48.6%',
-            left: sidebarOpen ? { xs: '50vw', md: 'calc(50vw - min(10%, 140px))' } : '50vw',
-            transform: 'translate(-50%, -50%)',
-            transition: 'left 0.3s ease-in-out',
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            width: '50vw',
-            pointerEvents: 'none',
-            zIndex: { xs: '2', md: '1' },
-        },
-        promptStyle: {
-            textAlign: 'center',
-            fontSize: '1.3em',
-            // media query to detect mobile in landscape mode. be aware that most devices will have 800px wide on landscape
-            // for this case we want to save as much space as possible
-            '@media (orientation: landscape) and (max-width:932px)': { fontSize: '1rem' },
-            textShadow: '1px 1px 6px black',
-            padding: '0.5rem',
-            position: 'relative',
-            borderRadius: '20px',
-            background: !menuTitle ? 'transparent' : promptTitle
-                ? 'radial-gradient(ellipse 90% 65% at center 55%, rgba(0, 123, 255, 1) 0%, rgba(0, 123, 255, 0.6) 60%, transparent 100%)'
-                : 'radial-gradient(ellipse 90% 65% at center 55%, rgba(220, 53, 69, 0.8) 0%, rgba(220, 53, 69, 0.4) 60%, transparent 100%)',
-        },
-        promptShadow: {
-            position: 'absolute',
-            top: '27%',
-            left: 0,
-            width: '100%',
-            height: '60%',
-            zIndex: -1,
-            background: 'rgba(0, 0, 0, .9)',
-            filter: 'blur(10px)',
-            WebkitFilter: 'blur(10px)'
-        },
+
         playerPlaymat: {
             position: 'absolute',
             bottom: 0, // Touch bottom edge
@@ -226,18 +186,10 @@ const GameBoard = () => {
                 </Box>
             </Box>
 
-
             <ChatDrawer
                 sidebarOpen={sidebarOpen}
                 toggleSidebar={toggleSidebar}
             />
-
-            <Box sx={styles.centralPromptContainer}>
-                <Box sx={styles.promptStyle}>
-                    {menuTitle && <RichText text={menuTitle}/>}
-                    <Box sx={styles.promptShadow}/>
-                </Box>
-            </Box>
 
             <PopupShell sidebarOpen={sidebarOpen}/>
             {isPreferenceOpen && <PreferencesComponent

--- a/src/app/_components/Gameboard/Board/Board.tsx
+++ b/src/app/_components/Gameboard/Board/Board.tsx
@@ -7,6 +7,7 @@ import { useGame } from '@/app/_contexts/Game.context';
 import LeaderBaseCard from '@/app/_components/_sharedcomponents/Cards/LeaderBaseCard';
 import { ICardData, LeaderBaseCardStyle } from '../../_sharedcomponents/Cards/CardTypes';
 import useScreenOrientation from '@/app/_utils/useScreenOrientation';
+import RichText from '@/app/_components/_sharedcomponents/RichText/RichText';
 
 const Board: React.FC<IBoardProps> = ({
     sidebarOpen,
@@ -29,6 +30,9 @@ const Board: React.FC<IBoardProps> = ({
 
     const playerCapturedCards = gameState?.players[connectedPlayer].cardPiles['capturedZone'];
     const opponentCapturedCards = gameState?.players[opponentId].cardPiles['capturedZone'];
+
+    const promptTitle = gameState?.players[connectedPlayer].promptState.promptTitle;
+    const menuTitle = gameState?.players[connectedPlayer].promptState.menuTitle;
 
     const attachCapturedCards = (
         card: ICardData,
@@ -234,6 +238,44 @@ const Board: React.FC<IBoardProps> = ({
                 color: !initiativeClaimed && hasInitiative ? 'var(--initiative-blue)' : !initiativeClaimed && !hasInitiative ? 'var(--initiative-red)' : 'black',
             }
         },
+        centralPromptContainer: {
+            flex: '0 1 60px',
+            width: '100%',
+            minHeight: '16px',
+            textWrap: 'nowrap',
+            //transform: 'translateY(-50%)',
+            transition: 'left 0.3s ease-in-out',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            pointerEvents: 'none',
+            zIndex: { xs: '2', md: '1' },
+        },
+        promptStyle: {
+            textAlign: 'center',
+            fontSize: '1.3em',
+            // media query to detect mobile in landscape mode. be aware that most devices will have 800px wide on landscape
+            // for this case we want to save as much space as possible
+            '@media (orientation: landscape) and (max-width:932px)': { fontSize: '1rem' },
+            textShadow: '1px 1px 6px black',
+            padding: '0.5rem',
+            position: 'relative',
+            borderRadius: '20px',
+            background: !menuTitle ? 'transparent' : promptTitle
+                ? 'radial-gradient(ellipse 90% 65% at center 55%, rgba(0, 123, 255, 1) 0%, rgba(0, 123, 255, 0.6) 60%, transparent 100%)'
+                : 'radial-gradient(ellipse 90% 65% at center 55%, rgba(220, 53, 69, 0.8) 0%, rgba(220, 53, 69, 0.4) 60%, transparent 100%)',
+        },
+        promptShadow: {
+            position: 'absolute',
+            top: '27%',
+            left: 0,
+            width: '100%',
+            height: '60%',
+            zIndex: -1,
+            background: 'rgba(0, 0, 0, .9)',
+            filter: 'blur(10px)',
+            WebkitFilter: 'blur(10px)'
+        },
     }
 
     return (
@@ -270,7 +312,12 @@ const Board: React.FC<IBoardProps> = ({
                             />
                         </Box>
                     </Box>
-                    <Box sx={{ flex: '0 1 60px', width: '100%', minHeight: '16px' }} />
+                    <Box sx={styles.centralPromptContainer}>
+                        <Box sx={styles.promptStyle}>
+                            {menuTitle && <RichText text={menuTitle}/>}
+                            <Box sx={styles.promptShadow}/>
+                        </Box>
+                    </Box>
                     <Box sx={styles.leaderBaseContainer}>
                         <Box sx={styles.leaderBaseWrapper}>
                             <LeaderBaseCard

--- a/src/app/_components/Gameboard/Board/Board.tsx
+++ b/src/app/_components/Gameboard/Board/Board.tsx
@@ -243,7 +243,6 @@ const Board: React.FC<IBoardProps> = ({
             width: '100%',
             minHeight: '16px',
             textWrap: 'nowrap',
-            //transform: 'translateY(-50%)',
             transition: 'left 0.3s ease-in-out',
             display: 'flex',
             justifyContent: 'center',


### PR DESCRIPTION
## Summary 

Fixes #758

The issue appears on small devices when things don't fit on the screen so absolute positioning stops working. The fix is to move the prompt to the space between user bases.

## Before

Mobile landscape (prompt starts to move on top of the opponent's base)
<img width="450" alt="absolute_landscape_iphonese" src="https://github.com/user-attachments/assets/5eada6e5-2076-4c9c-924d-a094ed8ae56c" />

Desktop
<img width="900" alt="absolute_desktop" src="https://github.com/user-attachments/assets/9d811606-b734-4936-9a37-63223036c1a9" />

Mobile portrait
<img width="450" alt="absolute_iphonese" src="https://github.com/user-attachments/assets/46ce7379-8f48-4d5e-bb19-30938f94f12e" />

## After

Mobile landscape: Prompt now is in the middle between bases
<img width="450" alt="relative_landscape_iphonese" src="https://github.com/user-attachments/assets/ffe1200c-8431-4f35-b445-05afdbd0bc6f" />  


Desktop: No changes
<img width="900" alt="relative_desktop" src="https://github.com/user-attachments/assets/78704c9c-a212-4814-981b-daa947ac6cba" />

Mobile portrait: No changes
<img width="450" alt="relative_iphonese" src="https://github.com/user-attachments/assets/0e1b004f-bbbb-4a13-a579-deab7c00a275" />

