### PR TITLE
Replace native alerts with recovery dialogs

### DIFF
--- a/src/app/DeckPage/page.tsx
+++ b/src/app/DeckPage/page.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/app/_utils/ServerAndLocalStorageUtils';
 import { useUser } from '@/app/_contexts/User.context';
 import { useSession } from 'next-auth/react';
+import { useErrorRecovery } from '@/app/_contexts/ErrorRecovery.context';
 
 interface IDeckSummaryCardTileProps {
     cardId: string;
@@ -68,6 +69,7 @@ const DeckPage: React.FC = () => {
     const router = useRouter();
     const { data: session } = useSession(); // Get session from next-auth
     const { user } = useUser();
+    const { showError } = useErrorRecovery();
 
     // Load decks from localStorage on component mount
     useEffect(() => {
@@ -80,8 +82,15 @@ const DeckPage: React.FC = () => {
             // Call the loadDecks function and await the result
             await retrieveDecksForUser(session?.user, user,{ format:'display', setDecks: setDecks });
         } catch (error) {
-            alert('Server error when fetching decks');
             console.error('Error fetching decks:', error);
+            showError({
+                title: 'Decks could not be loaded',
+                message: 'Server error when fetching decks.',
+                actions: [
+                    { label: 'Retry', onClick: () => void fetchDecks(), variant: 'warning' },
+                    { label: 'Close' },
+                ],
+            });
         }
     };
 
@@ -217,8 +226,15 @@ const DeckPage: React.FC = () => {
 
             setDecks(sortedDecks);
         }catch(error){
-            alert('There was an error when toggling favorite.');
             console.log(error)
+            showError({
+                title: 'Favorite could not be updated',
+                message: 'There was an error when toggling favorite.',
+                actions: [
+                    { label: 'Refresh', onClick: () => void fetchDecks(), variant: 'warning' },
+                    { label: 'Close' },
+                ],
+            });
         }
     };
 

--- a/src/app/_components/ClientProviders/ClientProviders.tsx
+++ b/src/app/_components/ClientProviders/ClientProviders.tsx
@@ -2,6 +2,7 @@
 
 import { CardImageLocaleProvider } from '@/app/_contexts/CardImageLocale.context';
 import { CosmeticsProvider } from '@/app/_contexts/CosmeticsContext';
+import { ErrorRecoveryProvider } from '@/app/_contexts/ErrorRecovery.context';
 import { PopupProvider } from '@/app/_contexts/Popup.context';
 import { ThemeContextProvider } from '@/app/_contexts/Theme.context';
 import { TimerVisibilityProvider } from '@/app/_contexts/TimerVisibility.context';
@@ -20,7 +21,9 @@ const ClientProviders: React.FC<IClientProvidersProps> = ({ children }) => {
                     <TimerVisibilityProvider>
                         <PopupProvider>
                             <CosmeticsProvider>
-                                <ThemeContextProvider>{children}</ThemeContextProvider>
+                                <ThemeContextProvider>
+                                    <ErrorRecoveryProvider>{children}</ErrorRecoveryProvider>
+                                </ThemeContextProvider>
                             </CosmeticsProvider>
                         </PopupProvider>
                     </TimerVisibilityProvider>

--- a/src/app/_components/HomePage/_subcomponents/JoinableGame/JoinableGame.tsx
+++ b/src/app/_components/HomePage/_subcomponents/JoinableGame/JoinableGame.tsx
@@ -14,10 +14,12 @@ import OpenIcon from '/public/open.svg';
 import NextSetIcon from '/public/next_set.svg';
 import Bo1Icon from '/public/bo1.svg';
 import Bo3Icon from '/public/bo3.svg';
+import { useErrorRecovery } from '@/app/_contexts/ErrorRecovery.context';
 
 const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
     const router = useRouter();
     const { user } = useUser();
+    const { showError } = useErrorRecovery();
 
     const joinLobby = async (lobbyId: string) => {
         try {
@@ -37,7 +39,14 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
             if (!response.ok) {
                 const errorData = await response.json();
                 console.error('Error joining lobby:', errorData.message);
-                alert(errorData.message);
+                showError({
+                    title: 'Unable to join lobby',
+                    message: errorData.message,
+                    actions: [
+                        { label: 'Retry', onClick: () => void joinLobby(lobbyId), variant: 'warning' },
+                        { label: 'Refresh', onClick: () => router.refresh() },
+                    ],
+                });
                 return;
             }
             router.push('/lobby');

--- a/src/app/_components/QuickGame/SearchingForGame/SearchingForGame.tsx
+++ b/src/app/_components/QuickGame/SearchingForGame/SearchingForGame.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Box, Card, Typography } from '@mui/material';
 import { useGame } from '@/app/_contexts/Game.context';
 import { useRouter } from 'next/navigation';
 import { useUser } from '@/app/_contexts/User.context';
 import MatchLoader from './MatchLoader';
+import { useErrorRecovery } from '@/app/_contexts/ErrorRecovery.context';
 const styles = {
     searchBox: {
         width: '35rem',
@@ -39,15 +40,31 @@ const SearchingForGame: React.FC = () => {
     const { lastQueueHeartbeat, createNewSocket } = useGame();
     const router = useRouter();
     const lastQueueHeartbeatState = useRef<number>(0);
+    const connectionLostRef = useRef(false);
     const { user, anonymousUserId } = useUser();
+    const { showError } = useErrorRecovery();
 
     useEffect(() => {
         timerRef.current = setInterval(() => {
             const secondsSinceLastHeartbeat = Math.floor((Date.now() - lastQueueHeartbeatState.current) / 1000);
 
-            if (secondsSinceLastHeartbeat > 15) {
-                alert(`Connection lost. Please try again.\nUser ID: ${user?.id || anonymousUserId}`);
-                router.push('/');
+            if (secondsSinceLastHeartbeat > 15 && !connectionLostRef.current) {
+                connectionLostRef.current = true;
+                showError({
+                    title: 'Connection lost',
+                    message: `Connection lost. Please try again.\nUser ID: ${user?.id || anonymousUserId}`,
+                    actions: [
+                        {
+                            label: 'Reconnect',
+                            onClick: () => {
+                                connectionLostRef.current = false;
+                                createNewSocket();
+                            },
+                            variant: 'warning',
+                        },
+                        { label: 'Home', onClick: () => router.push('/') },
+                    ],
+                });
                 return;
             }
 
@@ -64,7 +81,7 @@ const SearchingForGame: React.FC = () => {
         return () => {
             if (timerRef.current) clearInterval(timerRef.current);
         };
-    }, []);
+    }, [anonymousUserId, createNewSocket, router, showError, user?.id]);
 
     useEffect(() => {
         lastQueueHeartbeatState.current = lastQueueHeartbeat;

--- a/src/app/_components/_sharedcomponents/Error/RecoveryErrorDialog.tsx
+++ b/src/app/_components/_sharedcomponents/Error/RecoveryErrorDialog.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import React from 'react';
+import { Box, Dialog, DialogActions, DialogContent, Typography } from '@mui/material';
+import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
+
+export type RecoveryErrorActionVariant = 'standard' | 'concede' | 'warning';
+
+export interface IRecoveryErrorAction {
+    label: string;
+    onClick: () => void;
+    variant?: RecoveryErrorActionVariant;
+}
+
+interface IRecoveryErrorDialogProps {
+    open: boolean;
+    title: string;
+    message: React.ReactNode;
+    actions: IRecoveryErrorAction[];
+    onClose: () => void;
+}
+
+const RecoveryErrorDialog: React.FC<IRecoveryErrorDialogProps> = ({
+    open,
+    title,
+    message,
+    actions,
+    onClose,
+}) => {
+    const styles = {
+        dialog: {
+            '& .MuiDialog-paper': {
+                backgroundColor: '#1E2D32',
+                borderRadius: '12px',
+                maxWidth: '520px',
+                width: 'calc(100% - 32px)',
+                padding: '20px',
+                border: '2px solid transparent',
+                background:
+                    'linear-gradient(#0F1F27, #030C13) padding-box, linear-gradient(to top, #30434B, #50717D) border-box',
+            },
+        },
+        content: {
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: '16px',
+            padding: '12px 8px 4px',
+        },
+        iconFrame: {
+            width: '44px',
+            height: '44px',
+            borderRadius: '50%',
+            border: '1px solid #C40000',
+            color: '#FF6B6B',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: '28px',
+            fontWeight: 700,
+            lineHeight: 1,
+            backgroundColor: 'rgba(124, 7, 7, 0.24)',
+        },
+        title: {
+            color: '#FFFFFF',
+            fontSize: '1.35rem',
+            fontWeight: 700,
+            textAlign: 'center',
+        },
+        message: {
+            color: '#B4DCEB',
+            fontSize: '1rem',
+            lineHeight: 1.5,
+            textAlign: 'center',
+            whiteSpace: 'pre-line',
+        },
+        actions: {
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+            padding: '20px 0 0',
+            gap: '12px',
+        },
+        button: {
+            minWidth: '112px',
+        },
+    } as const;
+
+    return (
+        <Dialog
+            open={open}
+            onClose={onClose}
+            aria-labelledby="recovery-error-dialog-title"
+            aria-describedby="recovery-error-dialog-message"
+            sx={styles.dialog}
+        >
+            <DialogContent sx={styles.content}>
+                <Box sx={styles.iconFrame}>!</Box>
+                <Typography sx={styles.title} id="recovery-error-dialog-title">
+                    {title}
+                </Typography>
+                <Typography sx={styles.message} id="recovery-error-dialog-message" component="div">
+                    {message}
+                </Typography>
+            </DialogContent>
+            <DialogActions sx={styles.actions}>
+                {actions.map((action) => (
+                    <PreferenceButton
+                        key={action.label}
+                        text={action.label}
+                        variant={action.variant ?? 'standard'}
+                        buttonFnc={action.onClick}
+                        sx={styles.button}
+                    />
+                ))}
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default RecoveryErrorDialog;

--- a/src/app/_components/_sharedcomponents/LinkService/LinkServiceButton.tsx
+++ b/src/app/_components/_sharedcomponents/LinkService/LinkServiceButton.tsx
@@ -11,6 +11,7 @@ import { useTheme } from '@mui/material/styles';
 import { useUser } from '@/app/_contexts/User.context';
 import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
 import { IUser } from '@/app/_contexts/UserTypes';
+import { useErrorRecovery } from '@/app/_contexts/ErrorRecovery.context';
 
 type Props = {
     serviceName: string;
@@ -30,6 +31,7 @@ function LinkServiceButton({
     const theme = useTheme();
     const { user } = useUser();
     const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+    const { showError } = useErrorRecovery();
 
     const handleClick = async () => {
         if (linked) {
@@ -45,7 +47,14 @@ function LinkServiceButton({
             onLinkChange(false);
         } catch (error) {
             if (error instanceof Error) {
-                alert(error.message);
+                showError({
+                    title: `${serviceName} could not be unlinked`,
+                    message: error.message,
+                    actions: [
+                        { label: 'Retry', onClick: () => void handleConfirmUnlink(), variant: 'warning' },
+                        { label: 'Close' },
+                    ],
+                });
             }
             console.error(`Failed to unlink ${serviceName}:`, error);
         } finally {

--- a/src/app/_contexts/ErrorRecovery.context.tsx
+++ b/src/app/_contexts/ErrorRecovery.context.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import React, { createContext, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
+import RecoveryErrorDialog, {
+    IRecoveryErrorAction,
+    RecoveryErrorActionVariant,
+} from '@/app/_components/_sharedcomponents/Error/RecoveryErrorDialog';
+
+interface IShowRecoveryErrorAction {
+    label: string;
+    onClick?: () => void;
+    variant?: RecoveryErrorActionVariant;
+}
+
+interface IShowRecoveryErrorOptions {
+    title?: string;
+    message: ReactNode;
+    actions?: IShowRecoveryErrorAction[];
+}
+
+interface IRecoveryErrorState {
+    title: string;
+    message: ReactNode;
+    actions: IShowRecoveryErrorAction[];
+}
+
+interface IErrorRecoveryContext {
+    showError: (options: IShowRecoveryErrorOptions) => void;
+    dismissError: () => void;
+}
+
+const ErrorRecoveryContext = createContext<IErrorRecoveryContext | undefined>(undefined);
+
+export const ErrorRecoveryProvider = ({ children }: { children: ReactNode }) => {
+    const [errorState, setErrorState] = useState<IRecoveryErrorState | null>(null);
+
+    const dismissError = useCallback(() => {
+        setErrorState(null);
+    }, []);
+
+    const showError = useCallback((options: IShowRecoveryErrorOptions) => {
+        setErrorState({
+            title: options.title ?? 'Something went wrong',
+            message: options.message,
+            actions: options.actions?.length ? options.actions : [{ label: 'Close' }],
+        });
+    }, []);
+
+    const dialogActions: IRecoveryErrorAction[] = useMemo(() => {
+        return (errorState?.actions ?? []).map((action) => ({
+            label: action.label,
+            variant: action.variant,
+            onClick: () => {
+                dismissError();
+                action.onClick?.();
+            },
+        }));
+    }, [dismissError, errorState?.actions]);
+
+    return (
+        <ErrorRecoveryContext.Provider value={{ showError, dismissError }}>
+            {children}
+            <RecoveryErrorDialog
+                open={Boolean(errorState)}
+                title={errorState?.title ?? ''}
+                message={errorState?.message ?? ''}
+                actions={dialogActions}
+                onClose={dismissError}
+            />
+        </ErrorRecoveryContext.Provider>
+    );
+};
+
+export const useErrorRecovery = () => {
+    const context = useContext(ErrorRecoveryContext);
+
+    if (!context) {
+        throw new Error('useErrorRecovery must be used within ErrorRecoveryProvider');
+    }
+
+    return context;
+};

--- a/src/app/_contexts/Game.context.tsx
+++ b/src/app/_contexts/Game.context.tsx
@@ -23,6 +23,7 @@ import { IStatsNotification } from '@/app/_components/_sharedcomponents/Preferen
 import { hasSelectedCards } from '../_utils/gameStateHelpers';
 import { useGameMessages, IMessageDelta, IMessageRetransmit } from '@/app/_hooks/useGameMessages';
 import { IChatEntry } from '@/app/_components/_sharedcomponents/Chat/ChatTypes';
+import { useErrorRecovery } from '@/app/_contexts/ErrorRecovery.context';
 
 interface IGameContextType {
     gameState: any;
@@ -74,6 +75,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     const { distributionPromptData, setDistributionPrompt, clearDistributionPrompt, initDistributionPrompt } = useDistributionPrompt();
     const { data: session, status } = useSession();
     const { messages: gameMessages, processMessageDeltas, processMessageRetransmit, resetMessages } = useGameMessages();
+    const { showError } = useErrorRecovery();
 
     // Initialize sound handler with user preferences
     const { playSound } = useSoundHandler({
@@ -259,8 +261,14 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
 
         newSocket.on('connection_error', (error: any) => {
             console.error('Error joining lobby:', error);
-            alert(error);
-            router.push('/');
+            showError({
+                title: 'Unable to join lobby',
+                message: String(error),
+                actions: [
+                    { label: 'Refresh', onClick: () => window.location.reload(), variant: 'warning' },
+                    { label: 'Home', onClick: () => router.push('/') },
+                ],
+            });
         });
 
         newSocket.on('matchmakingFailed', (error: any) => {
@@ -268,9 +276,16 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
             resetStates();
         });
 
-        newSocket.on('inactiveDisconnect', () => {            
-            alert('You have been disconnected due to inactivity');
+        newSocket.on('inactiveDisconnect', () => {
             newSocket.disconnect();
+            showError({
+                title: 'Disconnected',
+                message: 'You have been disconnected due to inactivity.',
+                actions: [
+                    { label: 'Reconnect', onClick: createNewSocket, variant: 'warning' },
+                    { label: 'Home', onClick: () => router.push('/') },
+                ],
+            });
         });
 
         newSocket.on('gamestate', (gameState: any) => {

--- a/src/app/_hooks/useDeckManagement.ts
+++ b/src/app/_hooks/useDeckManagement.ts
@@ -9,6 +9,7 @@ import {
 } from '@/app/_utils/ServerAndLocalStorageUtils';
 import { useUser } from '@/app/_contexts/User.context';
 import { useSession } from 'next-auth/react';
+import { useErrorRecovery } from '@/app/_contexts/ErrorRecovery.context';
 
 export interface IDeckPreferences {
     showSavedDecks: boolean;
@@ -48,6 +49,7 @@ export interface IDeckManagementState {
 export const useDeckManagement = (): IDeckManagementState => {
     const { user } = useUser();
     const { data: session } = useSession();
+    const { showError } = useErrorRecovery();
     
     // Deck Preferences State
     const [showSavedDecks, setShowSavedDecks] = useState<boolean>(() => {
@@ -292,11 +294,18 @@ export const useDeckManagement = (): IDeckManagementState => {
             });
         } catch (error) {
             console.error('Error fetching decks:', error);
-            alert('Server error when fetching decks');
+            showError({
+                title: 'Decks could not be loaded',
+                message: 'Server error when fetching decks.',
+                actions: [
+                    { label: 'Retry', onClick: () => void fetchDecks(), variant: 'warning' },
+                    { label: 'Close' },
+                ],
+            });
         } finally {
             setIsLoadingSavedDecks(false);
         }
-    }, [session?.user, user, handleInitializeDeckSelection]);
+    }, [session?.user, user, handleInitializeDeckSelection, showError]);
 
     const handleShowSavedDecksChange = useCallback((value: boolean) => {
         setShowSavedDecks(value);

--- a/src/app/mod/subpages/CosmeticsManagerTab.tsx
+++ b/src/app/mod/subpages/CosmeticsManagerTab.tsx
@@ -24,6 +24,7 @@ import { ICosmeticEntity, RegisteredCosmeticType } from '@/app/_components/_shar
 import { v4 as uuidv4 } from 'uuid';
 import { useCosmetics } from '@/app/_contexts/CosmeticsContext';
 import { ServerApiService } from '@/app/_services/ServerApiService';
+import { useErrorRecovery } from '@/app/_contexts/ErrorRecovery.context';
 
 interface ImageDimensions {
     width: number;
@@ -40,6 +41,7 @@ const isDev = process.env.NODE_ENV === 'development';
 
 const CosmeticsManagerTab: React.FC = () => {
     const { cosmetics, setCosmetics, fetchCosmetics } = useCosmetics();
+    const { showError } = useErrorRecovery();
     const [filteredCosmetics, setFilteredCosmetics] = useState<ICosmeticEntity[]>([]);
     const [availableTypes, setAvailableTypes] = useState<string[]>([]);
     const [loading, setLoading] = useState(true);
@@ -365,8 +367,15 @@ const CosmeticsManagerTab: React.FC = () => {
         }
         const response = await ServerApiService.deleteCosmeticAsync(cosmeticId);
         if (!response.success) {
-            alert('Failed to delete cosmetic');
             console.error('Delete error:', response.message);
+            showError({
+                title: 'Cosmetic could not be deleted',
+                message: response.message || 'Failed to delete cosmetic.',
+                actions: [
+                    { label: 'Retry', onClick: () => void handleDeleteSingleCosmetic(cosmeticId), variant: 'warning' },
+                    { label: 'Close' },
+                ],
+            });
         }
 
         await fetchCosmetics();

--- a/src/stories/RecoveryErrorDialog.stories.tsx
+++ b/src/stories/RecoveryErrorDialog.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import RecoveryErrorDialog from '@/app/_components/_sharedcomponents/Error/RecoveryErrorDialog';
+
+const meta = {
+    title: 'Design/Dialogs/RecoveryErrorDialog',
+    component: RecoveryErrorDialog,
+    parameters: {
+        layout: 'centered',
+    },
+    args: {
+        open: true,
+        title: 'Connection lost',
+        message: 'Connection lost. Please try again.\nUser ID: anonymous',
+        onClose: () => {},
+        actions: [
+            { label: 'Reconnect', onClick: () => {}, variant: 'warning' },
+            { label: 'Home', onClick: () => {}, variant: 'standard' },
+        ],
+    },
+} satisfies Meta<typeof RecoveryErrorDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ConnectionLost: Story = {};
+
+export const RetryableError: Story = {
+    args: {
+        title: 'Decks could not be loaded',
+        message: 'Server error when fetching decks.',
+        actions: [
+            { label: 'Retry', onClick: () => {}, variant: 'warning' },
+            { label: 'Close', onClick: () => {}, variant: 'standard' },
+        ],
+    },
+};


### PR DESCRIPTION
## Summary
- Add a shared recovery error dialog and provider using the app's existing dialog/button styling.
- Replace browser-native error alerts with contextual recovery actions such as Retry, Refresh, Reconnect, Home, and Close.
- Add Storybook examples for connection loss and retryable error states.

## Impact
Users now see app-styled error recovery flows instead of blocking browser alerts, with actions tailored to the failure path.

## Validation
- npm run lint
- Confirmed no remaining alert() calls under src with rg