### PR TITLE
UI Board rework

### DIFF
--- a/src/app/GameBoard/page.tsx
+++ b/src/app/GameBoard/page.tsx
@@ -172,7 +172,6 @@ const GameBoard = () => {
                 <Box sx={{ height: '15dvh' }}>
                     <OpponentCardTray
                         trayPlayer={getOpponent(connectedPlayer)}
-                        preferenceToggle={handlePreferenceToggle}
                     />
                 </Box>
                 <Box sx={{ height: '67dvh', position: 'relative', zIndex: 2 }}>
@@ -189,6 +188,7 @@ const GameBoard = () => {
             <ChatDrawer
                 sidebarOpen={sidebarOpen}
                 toggleSidebar={toggleSidebar}
+                preferenceToggle={handlePreferenceToggle}
             />
 
             <PopupShell sidebarOpen={sidebarOpen}/>

--- a/src/app/_components/Gameboard/GameboardTypes.ts
+++ b/src/app/_components/Gameboard/GameboardTypes.ts
@@ -15,6 +15,7 @@ export interface IParticipant {
 export interface IChatDrawerProps {
     sidebarOpen: boolean;
     toggleSidebar: () => void;
+    preferenceToggle: () => void;
 }
 
 export interface IPlayerCardTrayProps {
@@ -24,7 +25,6 @@ export interface IPlayerCardTrayProps {
 
 export interface IOpponentCardTrayProps {
     trayPlayer: string;
-    preferenceToggle: () => void;
 }
 
 export interface IBoardProps {

--- a/src/app/_components/Gameboard/OpponentCardTray/OpponentCardTray.tsx
+++ b/src/app/_components/Gameboard/OpponentCardTray/OpponentCardTray.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { CloseOutlined, SettingsOutlined } from '@mui/icons-material';
 import { Box, Grid, Popover, PopoverOrigin } from '@mui/material';
 import Resources from '../_subcomponents/PlayerTray/Resources';
 import Credits from '../_subcomponents/PlayerTray/Credits';
@@ -9,31 +8,14 @@ import { IOpponentCardTrayProps } from '@/app/_components/Gameboard/GameboardTyp
 import { useGame } from '@/app/_contexts/Game.context';
 import { s3CardImageURL } from '@/app/_utils/s3Utils';
 import { useCardImageLocale } from '@/app/_contexts/CardImageLocale.context';
-import { v4 as uuidv4 } from 'uuid';
-import { usePopup } from '@/app/_contexts/Popup.context';
-import { PopupSource } from '@/app/_components/_sharedcomponents/Popup/Popup.types';
-import { useRouter } from 'next/navigation';
 import { debugBorder } from '@/app/_utils/debug';
 import useScreenOrientation from '@/app/_utils/useScreenOrientation';
 import GameTimer from '../_subcomponents/OpponentTray/GameTimer';
 
-const OpponentCardTray: React.FC<IOpponentCardTrayProps> = ({ trayPlayer, preferenceToggle }) => {
+const OpponentCardTray: React.FC<IOpponentCardTrayProps> = ({ trayPlayer }) => {
     const { gameState, connectedPlayer, getOpponent, isSpectator, gameIsEnded, lobbyState } = useGame();
-    const { openPopup } = usePopup();
     const { isPortrait } = useScreenOrientation();
     const locale = useCardImageLocale();
-    const router = useRouter();
-    const handleExitButton = () => {
-        if (isSpectator){
-            router.push('/');
-        } else {
-            const popupId = `${uuidv4()}`;
-            openPopup('leaveGame', {
-                uuid: popupId,
-                source: PopupSource.User
-            });
-        }
-    };
 
     const activePlayer = gameState.players[connectedPlayer].isActionPhaseActivePlayer;
     const phase = gameState.phase;
@@ -141,12 +123,6 @@ const OpponentCardTray: React.FC<IOpponentCardTrayProps> = ({ trayPlayer, prefer
             backgroundImage: lastPlayedCardUrl,
             backgroundRepeat: 'no-repeat',
         },
-        menuStyles: {
-            ...debugBorder('yellow'),
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '1rem',
-        },
         opponentTurnAura: {
             height: '100px',
             width: '90%',
@@ -238,10 +214,6 @@ const OpponentCardTray: React.FC<IOpponentCardTrayProps> = ({ trayPlayer, prefer
                 >
                     <Box sx={{ ...styles.lastCardPlayedPreview }} />
                 </Popover>
-                <Box sx={styles.menuStyles}>
-                    <CloseOutlined onClick={handleExitButton} sx={{ cursor:'pointer' }}/>
-                    <SettingsOutlined onClick={preferenceToggle} sx={{ cursor:'pointer' }} />
-                </Box>
             </Grid>
         </Grid>
     );

--- a/src/app/_components/Gameboard/PlayerCardTray/PlayerCardTray.tsx
+++ b/src/app/_components/Gameboard/PlayerCardTray/PlayerCardTray.tsx
@@ -68,7 +68,7 @@ const PlayerCardTray: React.FC<IPlayerCardTrayProps> = ({ trayPlayer, toggleSide
         },
         chatColumn: {
             ...debugBorder('yellow'),
-            display: 'flex',
+            display: { xs: 'none', md: 'flex' },
             alignItems: 'center',
             alignSelf: 'flex-end',
             height: { xs: '2.5rem', sm: '3rem', md: '3.8rem' },

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -118,7 +118,7 @@ const styles = {
         borderRadius: '11px 0 0 11px',
         boxShadow: '-2px 0 10px rgba(0, 186, 255, 0.48), inset 2px 0 6px rgba(255, 255, 255, 0.14)',
         pointerEvents: 'none',
-        zIndex: 1199,
+        zIndex: 9,
     },
     mobileClosedSwipeHintChevron: {
         width: '7px',

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -309,13 +309,21 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
         }
     }
 
+    const closeMobileDrawer = () => {
+        if (isMobile) {
+            handleDrawerClose();
+        }
+    }
+
     const handlePreferenceClick = () => {
         handleMenuClose();
+        closeMobileDrawer();
         preferenceToggle();
     }
 
     const handleLeaveGameClick = () => {
         handleMenuClose();
+        closeMobileDrawer();
         if (isSpectator){
             router.push('/');
         } else {
@@ -328,6 +336,7 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
 
     const handleDisableChatClick = () => {
         handleMenuClose();
+        closeMobileDrawer();
         setShowDisableChatConfirmation(true);
     }
 
@@ -342,6 +351,7 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
 
     const handleOpenPlayerReport = () => {
         handleMenuClose();
+        closeMobileDrawer();
         setPlayerReportOpen(true);
     };
 

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import {
     Drawer,
     Box,
+    Button,
     IconButton,
     Divider,
     Menu,
@@ -160,12 +161,25 @@ const styles = {
             background: 'rgba(255, 255, 255, 0.05)',
         },
     },
+    undoActionButton: {
+        minWidth: 0,
+        padding: '10px 12px',
+        borderRadius: '999px',
+        fontSize: '0.8rem',
+        fontWeight: 600,
+        lineHeight: 1,
+        textTransform: 'none',
+        whiteSpace: 'nowrap',
+        '& .MuiButton-startIcon': {
+            marginLeft: 0,
+            marginRight: '6px',
+        },
+    },
     collapseDrawerButton: {
         display: { xs: 'none', md: 'inline-flex' },
     },
     quickUndoButtonEnabled: {
-        borderColor: 'rgba(42, 212, 76, 0.7)',
-        boxShadow: '0 0 8px rgba(0, 170, 70, 0.45)',
+        borderColor: 'rgba(255, 255, 255, 0.12)',
     },
     quickUndoButtonDisabled: {
         borderColor: 'rgba(255, 255, 255, 0.12)',
@@ -236,22 +250,27 @@ const UndoButton = ({ disabledOverride = false }: { disabledOverride?: boolean }
             break;
     }
 
+    let buttonText;
     let buttonIcon;
     let ariaLabel;
     switch (quickUndoState) {
         case QuickUndoAvailableState.RequestUndoAvailable:
+            buttonText = 'Request';
             buttonIcon = <MessageIcon />;
             ariaLabel = 'request undo';
             break;
         case QuickUndoAvailableState.UndoRequestsBlocked:
+            buttonText = 'Blocked';
             buttonIcon = <BlockIcon />;
             ariaLabel = 'undo requests blocked';
             break;
         case QuickUndoAvailableState.WaitingForConfirmation:
+            buttonText = 'Waiting';
             buttonIcon = <BlockIcon />;
             ariaLabel = 'undo waiting for confirmation';
             break;
         default:
+            buttonText = 'Undo';
             buttonIcon = <UndoIcon />;
             ariaLabel = 'Undo last action';
             break;
@@ -260,14 +279,15 @@ const UndoButton = ({ disabledOverride = false }: { disabledOverride?: boolean }
     return (
         <Tooltip title={ariaLabel}>
             <span>
-                <IconButton
+                <Button
                     aria-label={ariaLabel}
                     onClick={handleUndoButton}
                     disabled={disabledOverride || undoButtonDisabled}
-                    sx={[styles.drawerActionButton, undoButtonStyle]}
+                    startIcon={buttonIcon}
+                    sx={[styles.drawerActionButton, styles.undoActionButton, undoButtonStyle]}
                 >
-                    {buttonIcon}
-                </IconButton>
+                    {buttonText}
+                </Button>
             </span>
         </Tooltip>
     )

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -140,6 +140,7 @@ const styles = {
         display: 'flex',
         alignItems: 'center',
         gap: '0.5rem',
+        ml: 'auto',
     },
     drawerActionButton: {
         padding: '10px',
@@ -157,6 +158,9 @@ const styles = {
             color: 'rgba(255, 255, 255, 0.45)',
             background: 'rgba(255, 255, 255, 0.05)',
         },
+    },
+    collapseDrawerButton: {
+        display: { xs: 'none', md: 'inline-flex' },
     },
     quickUndoButtonEnabled: {
         borderColor: 'rgba(42, 212, 76, 0.7)',
@@ -467,7 +471,7 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
     const drawerContent = (
         <>
             <Box sx={styles.headerBoxStyle}>
-                <IconButton aria-label="collapse drawer" onClick={toggleSidebar} sx={styles.drawerActionButton}>
+                <IconButton aria-label="collapse drawer" onClick={toggleSidebar} sx={[styles.drawerActionButton, styles.collapseDrawerButton]}>
                     <ChevronRightIcon />
                 </IconButton>
                 <Box sx={styles.headerActionsStyle}>

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -37,6 +37,7 @@ import { ChatDisabledReason, IChatDisabledInfo } from '@/app/_contexts/UserTypes
 import { getMuteDisplayText } from '@/app/_utils/ModerationUtils';
 import { LobbyConfirmationPopupModule } from '@/app/_components/Lobby/_subcomponents/LobbyConfirmationPopup/LobbyConfirmationPopup';
 import PlayerReportDialog from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PlayerReportDialog';
+import { Theme } from '@mui/material/styles';
 
 // ------------------------STYLES------------------------//
 const styles = {
@@ -122,6 +123,13 @@ const styles = {
         pointerEvents: 'none',
         zIndex: 9,
     },
+    mobileClosedSwipeHintButton: {
+        padding: 0,
+        cursor: 'pointer',
+        pointerEvents: 'auto',
+        // The drawer's invisible swipe area uses drawer - 1 and otherwise intercepts the click.
+        zIndex: (theme: Theme) => theme.zIndex.drawer,
+    },
     mobileClosedSwipeHintChevron: {
         width: '7px',
         height: '7px',
@@ -203,8 +211,15 @@ const styles = {
     },
 }
 
-const MobileClosedSwipeHint = () => (
-    <Box aria-hidden="true" sx={styles.mobileClosedSwipeHint}>
+const MobileClosedSwipeHint = ({ onClick }: { onClick?: () => void }) => (
+    <Box
+        aria-hidden={onClick ? undefined : true}
+        aria-label={onClick ? 'Open chat drawer' : undefined}
+        component={onClick ? 'button' : 'div'}
+        onClick={onClick}
+        sx={onClick ? [styles.mobileClosedSwipeHint, styles.mobileClosedSwipeHintButton] : styles.mobileClosedSwipeHint}
+        type={onClick ? 'button' : undefined}
+    >
         <Box component="span" sx={styles.mobileClosedSwipeHintChevron} />
     </Box>
 );
@@ -296,6 +311,8 @@ const UndoButton = ({ disabledOverride = false }: { disabledOverride?: boolean }
 const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, preferenceToggle }) => {
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+    // Allow clicking on devices with a mouse or trackpad, including touch-capable hybrids.
+    const hasFinePointer = useMediaQuery('(any-pointer: fine)');
     const {
         gameState,
         gameMessages,
@@ -570,7 +587,10 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
     if (isMobile) {
         return (
             <>
-                {!sidebarOpen && !isEdgeSwipeActive && <MobileClosedSwipeHint />}
+                {!sidebarOpen && !isEdgeSwipeActive && (
+                    // Enable click for mouse/trackpad input; touch-only devices continue to use swipe.
+                    <MobileClosedSwipeHint onClick={hasFinePointer ? handleDrawerOpen : undefined} />
+                )}
                 <SwipeableDrawer
                     anchor="right"
                     open={sidebarOpen}

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Drawer, Box, Button, IconButton, Divider } from '@mui/material';
+import { Drawer, Box, IconButton, Divider, Menu, MenuItem, ListItemIcon, ListItemText } from '@mui/material';
 import Chat from '@/app/_components/_sharedcomponents/Chat/Chat';
 import { IChatDrawerProps } from '@/app/_components/Gameboard/GameboardTypes';
 import { useGame } from '@/app/_contexts/Game.context';
@@ -7,37 +7,17 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import UndoIcon from '@mui/icons-material/Undo';
 import MessageIcon from '@mui/icons-material/Message';
 import BlockIcon from '@mui/icons-material/Block';
-import Image from 'next/image';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+import LogoutIcon from '@mui/icons-material/Logout';
 import { QuickUndoAvailableState } from '@/app/_constants/constants';
 import { useChatTypingState } from '@/app/_hooks/useChatTypingState';
+import { usePopup } from '@/app/_contexts/Popup.context';
+import { PopupSource } from '@/app/_components/_sharedcomponents/Popup/Popup.types';
+import { v4 as uuidv4 } from 'uuid';
+import { useRouter } from 'next/navigation';
 
 // ------------------------STYLES------------------------//
-const quickUndoButtonBase = {
-    height: { xs: 'auto', md: '45px' },
-    mb: { xs: 0, md: '10px' },
-    lineHeight: '1.2',
-    color: '#FFF',
-    fontSize: { xs: '0.9rem', md: '20px' },
-    border: '1px solid transparent',
-    borderRadius: '10px',
-    py: { xs: '6px', md: '10px' },
-    justifyContent: 'space-between',
-    pl: { xs: '16px', md: '12px' },
-    pr: { xs: '16px', md: '35px' },
-    position: 'relative',
-    '& .MuiButton-startIcon': {
-        marginRight: 0,
-        marginLeft: 0,
-        transform: 'skewX(5deg)',
-        display: { xs: 'none', sm: 'none', md: 'block' },
-        '& svg': {
-            width: '23px',
-            height: '23px',
-        },
-    },
-    transform: 'skewX(-5deg)',
-};
-
 const styles = {
     drawerStyle: {
         flexShrink: 0,
@@ -54,58 +34,59 @@ const styles = {
     headerBoxStyle: {
         display: 'flex',
         alignItems: 'center',
-        position: 'relative',
-        height: '1.5em',
+        justifyContent: 'space-between',
+        gap: '0.75rem',
+        mb: '0.75rem',
     },
-    quickUndoBox:{
-        display: 'inline-flex',
-        justifyContent: 'flex-start',
-        paddingLeft: { xs: 0, md: '0.5em' },
+    headerActionsStyle: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+    },
+    drawerActionButton: {
+        padding: '10px',
+        color: '#fff',
+        background: 'rgba(255, 255, 255, 0.08)',
+        backdropFilter: 'blur(20px)',
+        border: '1px solid rgba(255, 255, 255, 0.12)',
+        borderRadius: '50%',
+        '& svg': { fontSize: '1.45rem' },
+        '&:hover': {
+            background: 'rgba(255, 255, 255, 0.16)',
+            borderColor: 'rgba(255, 255, 255, 0.24)',
+        },
+        '&:disabled': {
+            color: 'rgba(255, 255, 255, 0.45)',
+            background: 'rgba(255, 255, 255, 0.05)',
+        },
     },
     quickUndoButtonEnabled: {
-        ...quickUndoButtonBase,
-        width: 'min(55%, 200px)',
-        background: 'linear-gradient(rgb(29, 29, 29), #0a3d1e) padding-box, linear-gradient(to top, #1cb34a, #0a3d1e) border-box',
-        '&:hover': {
-            background: 'linear-gradient(rgb(29, 29, 29),rgb(20, 81, 40)) padding-box, linear-gradient(to top, #2ad44c, #0a3d1e) border-box',
-            boxShadow: '0 0 8px rgba(0, 170, 70, 0.7)',
-            border: '1px solid rgba(0, 200, 90, 0.7)',
-        },
+        borderColor: 'rgba(42, 212, 76, 0.7)',
+        boxShadow: '0 0 8px rgba(0, 170, 70, 0.45)',
     },
     quickUndoButtonDisabled: {
-        ...quickUndoButtonBase,
-        width: 'min(55%, 200px)',
-        '&:disabled': {
-            backgroundColor: '#404040',
-            color: '#FFF'
-        },
+        borderColor: 'rgba(255, 255, 255, 0.12)',
     },
     quickUndoButtonBlocked: {
-        ...quickUndoButtonBase,
-        width: 'min(65%, 240px)',
-        '&:disabled': {
-            backgroundColor: '#404040',
-            color: '#FFF'
-        },
+        borderColor: 'rgba(255, 255, 255, 0.12)',
     },
     quickUndoButtonRequest: {
-        ...quickUndoButtonBase,
-        width: 'min(65%, 240px)',
-        background: 'linear-gradient(#1E2D32, #1E2D32) padding-box, linear-gradient(#404040, #008FC4) border-box',
-        '&:hover': {
-            background: 'linear-gradient(#2C4046, #2C4046) padding-box, linear-gradient(#404040, #008FC4) border-box',
-        },
+        borderColor: 'rgba(0, 143, 196, 0.8)',
+        boxShadow: '0 0 8px rgba(0, 143, 196, 0.45)',
     },
-    porgContainer: {
-        position:'relative',
-        left:'35px',
-        bottom:'28px',
-        display: { xs: 'none', md: 'block' },
+    menuPaper: {
+        backgroundColor: '#090f18',
+        color: '#fff',
+        border: '1px solid rgba(255, 255, 255, 0.12)',
+        minWidth: '190px',
+    },
+    menuIcon: {
+        color: '#E0E0E0',
+        minWidth: '36px',
     }
 }
-const UndoButton = () => {
+const UndoButton = ({ disabledOverride = false }: { disabledOverride?: boolean }) => {
     const { gameState, sendGameMessage, connectedPlayer } = useGame();
-    const [isUndoHovered, setIsUndoHovered] = useState(false);
     const correctPlayer = gameState.players[connectedPlayer];
     const quickUndoState: QuickUndoAvailableState | null = correctPlayer?.availableSnapshots?.quickSnapshotAvailable;
     const handleUndoButton = () => {
@@ -145,68 +126,50 @@ const UndoButton = () => {
             break;
     }
 
-    let buttonText;
-    switch (quickUndoState) {
-        case QuickUndoAvailableState.RequestUndoAvailable:
-            buttonText = 'Request';
-            break;
-        case QuickUndoAvailableState.UndoRequestsBlocked:
-            buttonText = 'Blocked';
-            break;
-        case QuickUndoAvailableState.WaitingForConfirmation:
-            buttonText = 'Waiting';
-            break;
-        default:
-            buttonText = 'Undo';
-            break;
-    }
-
     let buttonIcon;
+    let ariaLabel;
     switch (quickUndoState) {
         case QuickUndoAvailableState.RequestUndoAvailable:
             buttonIcon = <MessageIcon />;
+            ariaLabel = 'request undo';
             break;
         case QuickUndoAvailableState.UndoRequestsBlocked:
+            buttonIcon = <BlockIcon />;
+            ariaLabel = 'undo requests blocked';
+            break;
         case QuickUndoAvailableState.WaitingForConfirmation:
             buttonIcon = <BlockIcon />;
+            ariaLabel = 'undo waiting for confirmation';
             break;
         default:
             buttonIcon = <UndoIcon />;
+            ariaLabel = 'undo';
             break;
     }
 
     return (
-        <Box sx={styles.quickUndoBox}>
-            <Box sx={[styles.porgContainer, { visibility: isUndoHovered ? 'visible' : 'hidden' } ]}>
-                <Image
-                    src="/porg1.png"
-                    alt="Highlighted Stats Panel"
-                    width={50}
-                    height={50}
-                />
-            </Box>
-
-            <Button
-                variant="contained"
-                onClick={handleUndoButton}
-                onMouseEnter={() => setIsUndoHovered(true)}
-                onMouseLeave={() => setIsUndoHovered(false)}
-                disabled={undoButtonDisabled}
-                startIcon={buttonIcon}
-                sx={undoButtonStyle}
-            >
-                {buttonText}
-            </Button>
-        </Box>
+        <IconButton
+            aria-label={ariaLabel}
+            onClick={handleUndoButton}
+            disabled={disabledOverride || undoButtonDisabled}
+            sx={[styles.drawerActionButton, undoButtonStyle]}
+        >
+            {buttonIcon}
+        </IconButton>
     )
 }
 
-const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar }) => {
+const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, preferenceToggle }) => {
     const { gameState, gameMessages, sendGameMessage, isSpectator } = useGame();
     const { handleTypingStateOnChange, resetTypingState } = useChatTypingState();
     const [chatMessage, setChatMessage] = useState('')
+    const [menuAnchorElement, setMenuAnchorElement] = useState<null | HTMLElement>(null);
+    const { openPopup } = usePopup();
+    const router = useRouter();
     const isDev = process.env.NODE_ENV === 'development';
-    const isUndoEnabled = (isDev || gameState.undoEnabled) && (!isSpectator);
+    const isUndoEnabled = isDev || gameState.undoEnabled;
+    const shouldShowUndo = !isSpectator;
+    const isMenuOpen = Boolean(menuAnchorElement);
 
     const handleChatOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         handleTypingStateOnChange(event.target.value);
@@ -221,6 +184,31 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar }) 
         resetTypingState();
     }
 
+    const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+        setMenuAnchorElement(event.currentTarget);
+    }
+
+    const handleMenuClose = () => {
+        setMenuAnchorElement(null);
+    }
+
+    const handlePreferenceClick = () => {
+        handleMenuClose();
+        preferenceToggle();
+    }
+
+    const handleLeaveGameClick = () => {
+        handleMenuClose();
+        if (isSpectator){
+            router.push('/');
+        } else {
+            openPopup('leaveGame', {
+                uuid: `${uuidv4()}`,
+                source: PopupSource.User
+            });
+        }
+    }
+
     return (
         <Drawer
             anchor="right"
@@ -228,14 +216,44 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar }) 
             variant="persistent"
             sx={styles.drawerStyle}
         >
-            <Box sx={{ display: { xs: 'none', md: 'block' } }}>
-                <Box sx={styles.headerBoxStyle}>
-                    <IconButton onClick={toggleSidebar}>
-                        <ChevronRightIcon sx={{ color: 'white', fontSize: '28px' }}/>
+            <Box sx={styles.headerBoxStyle}>
+                <IconButton aria-label="collapse drawer" onClick={toggleSidebar} sx={styles.drawerActionButton}>
+                    <ChevronRightIcon />
+                </IconButton>
+                <Box sx={styles.headerActionsStyle}>
+                    {shouldShowUndo && (<UndoButton disabledOverride={!isUndoEnabled} />)}
+                    <IconButton
+                        aria-label="game menu"
+                        aria-controls={isMenuOpen ? 'chat-drawer-game-menu' : undefined}
+                        aria-haspopup="true"
+                        aria-expanded={isMenuOpen ? 'true' : undefined}
+                        onClick={handleMenuOpen}
+                        sx={styles.drawerActionButton}
+                    >
+                        <MoreHorizIcon />
                     </IconButton>
+                    <Menu
+                        id="chat-drawer-game-menu"
+                        anchorEl={menuAnchorElement}
+                        open={isMenuOpen}
+                        onClose={handleMenuClose}
+                        slotProps={{ paper: { sx: styles.menuPaper } }}
+                    >
+                        <MenuItem onClick={handlePreferenceClick}>
+                            <ListItemIcon sx={styles.menuIcon}>
+                                <SettingsOutlinedIcon fontSize="small" />
+                            </ListItemIcon>
+                            <ListItemText>Preferences</ListItemText>
+                        </MenuItem>
+                        <Divider sx={{ borderColor: 'rgba(255, 255, 255, 0.14)' }} />
+                        <MenuItem onClick={handleLeaveGameClick}>
+                            <ListItemIcon sx={styles.menuIcon}>
+                                <LogoutIcon fontSize="small" />
+                            </ListItemIcon>
+                            <ListItemText>Leave game</ListItemText>
+                        </MenuItem>
+                    </Menu>
                 </Box>
-
-                {isUndoEnabled && (<UndoButton />)}
             </Box>
 
 
@@ -246,17 +264,6 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar }) 
                 handleChatOnChange={handleChatOnChange}
                 handleChatSubmit={handleGameChat}
             />
-
-            <Box sx={{ display: { xs: 'block', md: 'none' } } }>
-                <Divider sx={{ backgroundColor: '#fff', mx: '-0.75em', my: '0.75em' }} />
-                <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                    {isUndoEnabled && (<UndoButton />)}
-                    <IconButton onClick={toggleSidebar}>
-                        <ChevronRightIcon sx={{ color: 'white', fontSize: '28px' }}/>
-                    </IconButton>
-                </Box>
-            </Box>
-
 
         </Drawer>
     );

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -51,6 +51,9 @@ const styles = {
         },
     },
     mobileDrawerStyle: {
+        '& .MuiBackdrop-root': {
+            backgroundColor: 'rgba(0, 0, 0, 0.25)',
+        },
         '& .MuiDrawer-paper': {
             backgroundColor: '#000000E6',
             color: '#fff',

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
     Drawer,
     Box,
@@ -61,8 +61,73 @@ const styles = {
             flexDirection: 'column',
             width: { xs: '200px', md: 'min(20%, 280px)' },
             padding: '0.75em',
-            overflow: 'hidden',
+            overflow: 'visible',
+            '&::before': {
+                content: '""',
+                position: 'absolute',
+                left: '-15px',
+                top: '50%',
+                transform: 'translateY(-50%)',
+                width: '15px',
+                height: '54px',
+                backgroundColor: '#000000E6',
+                border: '1px solid rgba(143, 214, 255, 0.85)',
+                borderRight: 'none',
+                borderRadius: '11px 0 0 11px',
+                transition: 'border-color 225ms ease',
+                pointerEvents: 'none',
+            },
+            '&::after': {
+                content: '""',
+                position: 'absolute',
+                left: '-10px',
+                top: '50%',
+                width: '7px',
+                height: '7px',
+                borderLeft: '2px solid #fff',
+                borderBottom: '2px solid #fff',
+                filter: 'drop-shadow(0 0 4px rgba(255, 255, 255, 0.55))',
+                transform: 'translateY(-50%) rotate(45deg)',
+                transition: 'transform 225ms ease',
+                pointerEvents: 'none',
+            },
         },
+    },
+    mobileDrawerOpenStyle: {
+        '& .MuiDrawer-paper::before': {
+            borderColor: 'rgba(255, 255, 255, 0.16)',
+            borderRight: 'none',
+        },
+        '& .MuiDrawer-paper::after': {
+            transform: 'translateY(-50%) rotate(225deg)',
+        },
+    },
+    mobileClosedSwipeHint: {
+        position: 'fixed',
+        right: 0,
+        top: '50%',
+        transform: 'translateY(-50%)',
+        width: '15px',
+        height: '54px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#000000E6',
+        border: '1px solid rgba(143, 214, 255, 0.85)',
+        borderRight: 0,
+        borderRadius: '11px 0 0 11px',
+        boxShadow: '-2px 0 10px rgba(0, 186, 255, 0.48), inset 2px 0 6px rgba(255, 255, 255, 0.14)',
+        pointerEvents: 'none',
+        zIndex: 1199,
+    },
+    mobileClosedSwipeHintChevron: {
+        width: '7px',
+        height: '7px',
+        borderLeft: '2px solid #fff',
+        borderBottom: '2px solid #fff',
+        filter: 'drop-shadow(0 0 4px rgba(255, 255, 255, 0.55))',
+        transform: 'rotate(45deg)',
+        marginLeft: '5px',
     },
     headerBoxStyle: {
         display: 'flex',
@@ -116,8 +181,15 @@ const styles = {
     menuIcon: {
         color: '#E0E0E0',
         minWidth: '36px',
-    }
+    },
 }
+
+const MobileClosedSwipeHint = () => (
+    <Box aria-hidden="true" sx={styles.mobileClosedSwipeHint}>
+        <Box component="span" sx={styles.mobileClosedSwipeHintChevron} />
+    </Box>
+);
+
 const UndoButton = ({ disabledOverride = false }: { disabledOverride?: boolean }) => {
     const { gameState, sendGameMessage, connectedPlayer } = useGame();
     const correctPlayer = gameState.players[connectedPlayer];
@@ -212,6 +284,7 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
     const [menuAnchorElement, setMenuAnchorElement] = useState<null | HTMLElement>(null);
     const [showDisableChatConfirmation, setShowDisableChatConfirmation] = useState(false);
     const [playerReportOpen, setPlayerReportOpen] = useState(false);
+    const [isEdgeSwipeActive, setIsEdgeSwipeActive] = useState(false);
     const { openPopup } = usePopup();
     const { user } = useUser();
     const router = useRouter();
@@ -227,6 +300,35 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
     const opponentChatDisabled = hasChatDisabled(opponentId);
     const canReportOpponent = !isSpectator && !isAnonymousPlayer(connectedPlayer) && (!!opponentId && !isAnonymousOpponent);
     const isReportingDisabled = !!user?.reportingDisabled;
+
+    useEffect(() => {
+        if (!isMobile || sidebarOpen) {
+            setIsEdgeSwipeActive(false);
+            return;
+        }
+
+        const handleTouchStart = (event: TouchEvent) => {
+            const touch = event.touches[0];
+
+            if (touch && touch.clientX >= window.innerWidth - 32) {
+                setIsEdgeSwipeActive(true);
+            }
+        };
+
+        const handleTouchEnd = () => {
+            setIsEdgeSwipeActive(false);
+        };
+
+        window.addEventListener('touchstart', handleTouchStart, { passive: true });
+        window.addEventListener('touchend', handleTouchEnd, { passive: true });
+        window.addEventListener('touchcancel', handleTouchEnd, { passive: true });
+
+        return () => {
+            window.removeEventListener('touchstart', handleTouchStart);
+            window.removeEventListener('touchend', handleTouchEnd);
+            window.removeEventListener('touchcancel', handleTouchEnd);
+        };
+    }, [isMobile, sidebarOpen]);
 
     const getChatDisabledInfo = (): IChatDisabledInfo => {
         if (isPrivateLobby && !doesUserHaveChatMuted) {
@@ -436,17 +538,21 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
 
     if (isMobile) {
         return (
-            <SwipeableDrawer
-                anchor="right"
-                open={sidebarOpen}
-                onOpen={handleDrawerOpen}
-                onClose={handleDrawerClose}
-                sx={styles.mobileDrawerStyle}
-                disableBackdropTransition
-                disableSwipeToOpen={false}
-            >
-                {drawerContent}
-            </SwipeableDrawer>
+            <>
+                {!sidebarOpen && !isEdgeSwipeActive && <MobileClosedSwipeHint />}
+                <SwipeableDrawer
+                    anchor="right"
+                    open={sidebarOpen}
+                    onOpen={handleDrawerOpen}
+                    onClose={handleDrawerClose}
+                    sx={sidebarOpen ? [styles.mobileDrawerStyle, styles.mobileDrawerOpenStyle] : styles.mobileDrawerStyle}
+                    disableBackdropTransition
+                    disableSwipeToOpen={false}
+                    swipeAreaWidth={15}
+                >
+                    {drawerContent}
+                </SwipeableDrawer>
+            </>
         );
     }
 

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -1,5 +1,17 @@
 import React, { useState } from 'react';
-import { Drawer, Box, IconButton, Divider, Menu, MenuItem, ListItemIcon, ListItemText } from '@mui/material';
+import {
+    Drawer,
+    Box,
+    IconButton,
+    Divider,
+    Menu,
+    MenuItem,
+    ListItemIcon,
+    ListItemText,
+    SwipeableDrawer,
+    useMediaQuery,
+    useTheme,
+} from '@mui/material';
 import Chat from '@/app/_components/_sharedcomponents/Chat/Chat';
 import { IChatDrawerProps } from '@/app/_components/Gameboard/GameboardTypes';
 import { useGame } from '@/app/_contexts/Game.context';
@@ -30,6 +42,17 @@ const styles = {
         flexShrink: 0,
         '& .MuiDrawer-paper': {
             backgroundColor: '#000000CC',
+            color: '#fff',
+            display: 'flex',
+            flexDirection: 'column',
+            width: { xs: '200px', md: 'min(20%, 280px)' },
+            padding: '0.75em',
+            overflow: 'hidden',
+        },
+    },
+    mobileDrawerStyle: {
+        '& .MuiDrawer-paper': {
+            backgroundColor: '#000000E6',
             color: '#fff',
             display: 'flex',
             flexDirection: 'column',
@@ -167,6 +190,8 @@ const UndoButton = ({ disabledOverride = false }: { disabledOverride?: boolean }
 }
 
 const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, preferenceToggle }) => {
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('md'));
     const {
         gameState,
         gameMessages,
@@ -272,6 +297,18 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
         setMenuAnchorElement(null);
     }
 
+    const handleDrawerOpen = () => {
+        if (!sidebarOpen) {
+            toggleSidebar();
+        }
+    }
+
+    const handleDrawerClose = () => {
+        if (sidebarOpen) {
+            toggleSidebar();
+        }
+    }
+
     const handlePreferenceClick = () => {
         handleMenuClose();
         preferenceToggle();
@@ -312,13 +349,8 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
         setPlayerReportOpen(false);
     };
 
-    return (
-        <Drawer
-            anchor="right"
-            open={sidebarOpen}
-            variant="persistent"
-            sx={styles.drawerStyle}
-        >
+    const drawerContent = (
+        <>
             <Box sx={styles.headerBoxStyle}>
                 <IconButton aria-label="collapse drawer" onClick={toggleSidebar} sx={styles.drawerActionButton}>
                     <ChevronRightIcon />
@@ -386,6 +418,33 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
 
             <LobbyConfirmationPopupModule title={'Disable Chat Confirmation'} message={'Are you sure you wish to disable chat for this game? This action is not reversable.'} display={showDisableChatConfirmation} onConfirmation={handleConfirmDisableChat} handleCancel={handleCancelDisableChat}/>
             <PlayerReportDialog open={playerReportOpen} onClose={handleClosePlayerReport}/>
+        </>
+    );
+
+    if (isMobile) {
+        return (
+            <SwipeableDrawer
+                anchor="right"
+                open={sidebarOpen}
+                onOpen={handleDrawerOpen}
+                onClose={handleDrawerClose}
+                sx={styles.mobileDrawerStyle}
+                disableBackdropTransition
+                disableSwipeToOpen={false}
+            >
+                {drawerContent}
+            </SwipeableDrawer>
+        );
+    }
+
+    return (
+        <Drawer
+            anchor="right"
+            open={sidebarOpen}
+            variant="persistent"
+            sx={styles.drawerStyle}
+        >
+            {drawerContent}
         </Drawer>
     );
 };

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -10,12 +10,19 @@ import BlockIcon from '@mui/icons-material/Block';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import LogoutIcon from '@mui/icons-material/Logout';
-import { QuickUndoAvailableState } from '@/app/_constants/constants';
+import CommentsDisabledIcon from '@mui/icons-material/CommentsDisabled';
+import ReportProblemIcon from '@mui/icons-material/ReportProblem';
+import { MatchmakingType, QuickUndoAvailableState } from '@/app/_constants/constants';
 import { useChatTypingState } from '@/app/_hooks/useChatTypingState';
 import { usePopup } from '@/app/_contexts/Popup.context';
 import { PopupSource } from '@/app/_components/_sharedcomponents/Popup/Popup.types';
 import { v4 as uuidv4 } from 'uuid';
 import { useRouter } from 'next/navigation';
+import { useUser } from '@/app/_contexts/User.context';
+import { ChatDisabledReason, IChatDisabledInfo } from '@/app/_contexts/UserTypes';
+import { getMuteDisplayText } from '@/app/_utils/ModerationUtils';
+import { LobbyConfirmationPopupModule } from '@/app/_components/Lobby/_subcomponents/LobbyConfirmationPopup/LobbyConfirmationPopup';
+import PlayerReportDialog from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PlayerReportDialog';
 
 // ------------------------STYLES------------------------//
 const styles = {
@@ -160,16 +167,89 @@ const UndoButton = ({ disabledOverride = false }: { disabledOverride?: boolean }
 }
 
 const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, preferenceToggle }) => {
-    const { gameState, gameMessages, sendGameMessage, isSpectator } = useGame();
+    const {
+        gameState,
+        gameMessages,
+        sendGameMessage,
+        sendLobbyMessage,
+        isSpectator,
+        lobbyState,
+        connectedPlayer,
+        getOpponent,
+        isAnonymousPlayer,
+        hasChatDisabled,
+    } = useGame();
     const { handleTypingStateOnChange, resetTypingState } = useChatTypingState();
     const [chatMessage, setChatMessage] = useState('')
     const [menuAnchorElement, setMenuAnchorElement] = useState<null | HTMLElement>(null);
+    const [showDisableChatConfirmation, setShowDisableChatConfirmation] = useState(false);
+    const [playerReportOpen, setPlayerReportOpen] = useState(false);
     const { openPopup } = usePopup();
+    const { user } = useUser();
     const router = useRouter();
     const isDev = process.env.NODE_ENV === 'development';
     const isUndoEnabled = isDev || gameState.undoEnabled;
     const shouldShowUndo = !isSpectator;
     const isMenuOpen = Boolean(menuAnchorElement);
+    const isPrivateLobby = lobbyState?.gameType === MatchmakingType.PrivateLobby;
+    const didCurrentUserMuteChat = lobbyState?.userWhoMutedChat === connectedPlayer;
+    const doesUserHaveChatMuted = user?.preferences?.gameOptions?.muteChat;
+    const opponentId = getOpponent(connectedPlayer);
+    const isAnonymousOpponent = isAnonymousPlayer(opponentId);
+    const opponentChatDisabled = hasChatDisabled(opponentId);
+    const canReportOpponent = !isSpectator && !isAnonymousPlayer(connectedPlayer) && (!!opponentId && !isAnonymousOpponent);
+    const isReportingDisabled = !!user?.reportingDisabled;
+
+    const getChatDisabledInfo = (): IChatDisabledInfo => {
+        if (isPrivateLobby && !doesUserHaveChatMuted) {
+            return { reason: ChatDisabledReason.None, message: '', borderColor: '' };
+        }
+
+        switch (true) {
+            case !user && process.env.NEXT_PUBLIC_FORCE_ENABLE_ANON_CHAT !== 'true':
+                return {
+                    reason: ChatDisabledReason.NotLoggedIn,
+                    message: 'Log in to enable chat',
+                    borderColor: 'red'
+                };
+            case !!(user?.moderation):
+                const muteText = getMuteDisplayText(user.moderation);
+                return {
+                    reason: ChatDisabledReason.UserMuted,
+                    message: `You are muted for ${muteText}`,
+                    borderColor: 'yellow'
+                };
+            case isAnonymousOpponent && process.env.NEXT_PUBLIC_FORCE_ENABLE_ANON_CHAT !== 'true':
+                return {
+                    reason: ChatDisabledReason.AnonymousOpponent,
+                    message: 'Chat disabled when playing against an anonymous opponent',
+                    borderColor: 'yellow'
+                };
+            case didCurrentUserMuteChat:
+                return {
+                    reason: ChatDisabledReason.UserDisabledChat,
+                    message: 'You disabled chat',
+                    borderColor: 'yellow'
+                };
+            case doesUserHaveChatMuted:
+                return {
+                    reason: ChatDisabledReason.UserDisabledChat,
+                    message: 'You have chat disabled in your account preferences',
+                    borderColor: 'yellow'
+                };
+            case opponentChatDisabled:
+                return {
+                    reason: ChatDisabledReason.OpponentDisabledChat,
+                    message: 'The opponent has disabled chat',
+                    borderColor: 'yellow'
+                };
+            default:
+                return { reason: ChatDisabledReason.None, message: '', borderColor: '' };
+        }
+    };
+
+    const chatDisabledInfo = getChatDisabledInfo();
+    const shouldShowChatInput = chatDisabledInfo.reason === ChatDisabledReason.None;
 
     const handleChatOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         handleTypingStateOnChange(event.target.value);
@@ -209,6 +289,29 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
         }
     }
 
+    const handleDisableChatClick = () => {
+        handleMenuClose();
+        setShowDisableChatConfirmation(true);
+    }
+
+    const handleConfirmDisableChat = () => {
+        sendLobbyMessage(['muteChat']);
+        setShowDisableChatConfirmation(false);
+    };
+
+    const handleCancelDisableChat = () => {
+        setShowDisableChatConfirmation(false);
+    };
+
+    const handleOpenPlayerReport = () => {
+        handleMenuClose();
+        setPlayerReportOpen(true);
+    };
+
+    const handleClosePlayerReport = () => {
+        setPlayerReportOpen(false);
+    };
+
     return (
         <Drawer
             anchor="right"
@@ -245,6 +348,22 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
                             </ListItemIcon>
                             <ListItemText>Preferences</ListItemText>
                         </MenuItem>
+                        {!isSpectator && (
+                            <MenuItem disabled={!shouldShowChatInput} onClick={handleDisableChatClick}>
+                                <ListItemIcon sx={styles.menuIcon}>
+                                    <CommentsDisabledIcon fontSize="small" />
+                                </ListItemIcon>
+                                <ListItemText>{shouldShowChatInput ? 'Disable chat' : 'Chat is disabled'}</ListItemText>
+                            </MenuItem>
+                        )}
+                        {!isSpectator && canReportOpponent && (
+                            <MenuItem disabled={isReportingDisabled} onClick={handleOpenPlayerReport}>
+                                <ListItemIcon sx={styles.menuIcon}>
+                                    <ReportProblemIcon fontSize="small" />
+                                </ListItemIcon>
+                                <ListItemText>{isReportingDisabled ? 'Reporting disabled' : 'Report Opponent'}</ListItemText>
+                            </MenuItem>
+                        )}
                         <Divider sx={{ borderColor: 'rgba(255, 255, 255, 0.14)' }} />
                         <MenuItem onClick={handleLeaveGameClick}>
                             <ListItemIcon sx={styles.menuIcon}>
@@ -265,6 +384,8 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
                 handleChatSubmit={handleGameChat}
             />
 
+            <LobbyConfirmationPopupModule title={'Disable Chat Confirmation'} message={'Are you sure you wish to disable chat for this game? This action is not reversable.'} display={showDisableChatConfirmation} onConfirmation={handleConfirmDisableChat} handleCancel={handleCancelDisableChat}/>
+            <PlayerReportDialog open={playerReportOpen} onClose={handleClosePlayerReport}/>
         </Drawer>
     );
 };

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -9,6 +9,7 @@ import {
     ListItemIcon,
     ListItemText,
     SwipeableDrawer,
+    Tooltip,
     useMediaQuery,
     useTheme,
 } from '@mui/material';
@@ -252,19 +253,23 @@ const UndoButton = ({ disabledOverride = false }: { disabledOverride?: boolean }
             break;
         default:
             buttonIcon = <UndoIcon />;
-            ariaLabel = 'undo';
+            ariaLabel = 'Undo last action';
             break;
     }
 
     return (
-        <IconButton
-            aria-label={ariaLabel}
-            onClick={handleUndoButton}
-            disabled={disabledOverride || undoButtonDisabled}
-            sx={[styles.drawerActionButton, undoButtonStyle]}
-        >
-            {buttonIcon}
-        </IconButton>
+        <Tooltip title={ariaLabel}>
+            <span>
+                <IconButton
+                    aria-label={ariaLabel}
+                    onClick={handleUndoButton}
+                    disabled={disabledOverride || undoButtonDisabled}
+                    sx={[styles.drawerActionButton, undoButtonStyle]}
+                >
+                    {buttonIcon}
+                </IconButton>
+            </span>
+        </Tooltip>
     )
 }
 
@@ -471,9 +476,11 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
     const drawerContent = (
         <>
             <Box sx={styles.headerBoxStyle}>
-                <IconButton aria-label="collapse drawer" onClick={toggleSidebar} sx={[styles.drawerActionButton, styles.collapseDrawerButton]}>
-                    <ChevronRightIcon />
-                </IconButton>
+                <Tooltip title="Collapse chat">
+                    <IconButton aria-label="collapse drawer" onClick={toggleSidebar} sx={[styles.drawerActionButton, styles.collapseDrawerButton]}>
+                        <ChevronRightIcon />
+                    </IconButton>
+                </Tooltip>
                 <Box sx={styles.headerActionsStyle}>
                     {shouldShowUndo && (<UndoButton disabledOverride={!isUndoEnabled} />)}
                     <IconButton

--- a/src/app/_components/Gameboard/_subcomponents/PlayerTray/CardActionTray.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/PlayerTray/CardActionTray.tsx
@@ -16,7 +16,7 @@ const createStyles = (isPortrait: boolean) => ({
         display: 'flex',
         justifyContent: 'flex-end',
         alignItems: 'flex-end', 
-        padding: { xs: '0.25rem', md: '0.5rem' },
+        padding: { xs: '0.25rem 15px 15px 0.25rem', md: '0.5rem' },
     },
     buttonsContainer: {
         ...debugBorder('purple'),
@@ -30,12 +30,12 @@ const createStyles = (isPortrait: boolean) => ({
         maxWidth: '100%',
     },
     promptButton: {
-        height: { xs: '2.5rem', sm: '3rem', md: '3.8rem' },
+        height: { xs: '3rem', md: '3.8rem' },
         minWidth: { xs: '1.5rem', md: '2.5rem' },
-        maxWidth: { xs: '5rem', sm: '7rem', md: '9rem' },
+        maxWidth: { xs: '6rem', sm: '7rem', md: '9rem' },
     },
     promptButtonText: {
-        fontSize: { xs: '0.6rem', sm: '0.9rem', md: '1.05rem' },
+        fontSize: { xs: '0.75rem', sm: '0.9rem', md: '1.05rem' },
     },
 });
 

--- a/src/app/_components/Gameboard/_subcomponents/PlayerTray/CardActionTray.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/PlayerTray/CardActionTray.tsx
@@ -31,7 +31,7 @@ const createStyles = (isPortrait: boolean) => ({
     },
     promptButton: {
         height: { xs: '3rem', md: '3.8rem' },
-        minWidth: { xs: '1.5rem', md: '2.5rem' },
+        minWidth: { xs: '6rem', md: '2.5rem' },
         maxWidth: { xs: '6rem', sm: '7rem', md: '9rem' },
     },
     promptButtonText: {

--- a/src/app/_components/_sharedcomponents/Chat/Chat.tsx
+++ b/src/app/_components/_sharedcomponents/Chat/Chat.tsx
@@ -315,16 +315,16 @@ const Chat: React.FC<IChatProps> = ({
             justifyContent: 'flex-end',
         },
         messageText: {
-            fontSize: { xs: '0.75em', md: '1em' },
+            fontSize: { xs: '0.95rem', md: '1em' },
             color: '#fff',
-            lineHeight: { xs: '0.75rem', md: '1rem' },
+            lineHeight: { xs: '1.25rem', md: '1rem' },
             m: 0
 
         },
         // Base style for alert messages
         alertBase: {
-            fontSize: { xs: '0.85em', md: '1em' },
-            lineHeight: { xs: '0.85rem', md: '1em' },
+            fontSize: { xs: '0.95rem', md: '1em' },
+            lineHeight: { xs: '1.25rem', md: '1em' },
         },
         chatEntryBox: {
             p: '1rem .25rem',
@@ -340,8 +340,9 @@ const Chat: React.FC<IChatProps> = ({
             alignItems: 'center',
             width: '100%',
             backgroundColor: '#28282800',
-            px: { xs: '0.2em', md: '0.5em' },
-            minHeight: { xs: '1.5rem', md: '2.6rem' },
+            px: { xs: '0.25rem', md: '0.5em' },
+            py: { xs: '0.25rem', md: 0 },
+            minHeight: { xs: '48px', md: '2.6rem' },
         },
         textField: {
             backgroundColor: '#28282800',
@@ -352,10 +353,17 @@ const Chat: React.FC<IChatProps> = ({
             maxWidth: '100%',
             minWidth: 0,
             width: '100%',
-            fontSize: { xs: '0.75em', md: '1em' },
-            height: { xs: '1.8rem', md: '2.2rem' },
-            input: { color: '#fff', padding: '0.3em 0.5em' },
+            fontSize: { xs: '1rem', md: '1em' },
+            height: { xs: '44px', md: '2.2rem' },
+            input: {
+                color: '#fff',
+                padding: { xs: '0 0.5rem', md: '0.3em 0.5em' },
+                height: { xs: '44px', md: 'auto' },
+                boxSizing: 'border-box',
+            },
             '& .MuiOutlinedInput-root': {
+                height: { xs: '44px', md: '2.2rem' },
+                pr: { xs: '4px', md: '8px' },
                 '& fieldset': {
                     borderColor: '#fff',
                 },
@@ -366,6 +374,15 @@ const Chat: React.FC<IChatProps> = ({
                 },
             },
         },
+        sendButton: {
+            width: { xs: '40px', md: '32px' },
+            height: { xs: '40px', md: '32px' },
+            p: 0,
+        },
+        sendIcon: {
+            color: '#fff',
+            fontSize: { xs: '1.35rem', md: '1.1em' },
+        },
         chatDisabled: (borderColor: string) => ({
             textAlign: 'center',
             border: `1px solid ${borderColor}`,
@@ -375,9 +392,9 @@ const Chat: React.FC<IChatProps> = ({
             mt: '0.5em',
             width: '100%',
             display: 'block',
-            fontSize: { xs: '0.75em', md: '1em' },
+            fontSize: { xs: '0.95rem', md: '1em' },
             color: '#fff',
-            lineHeight: { xs: '0.75rem', md: '1rem' },
+            lineHeight: { xs: '1.25rem', md: '1rem' },
             userSelect: 'none',
         }),
         typingState: {
@@ -385,7 +402,8 @@ const Chat: React.FC<IChatProps> = ({
                 px: { xs: '0.2em', md: '0.5em' }
             },
             typography: {
-                fontSize: '0.8rem'
+                fontSize: { xs: '0.9rem', md: '0.8rem' },
+                lineHeight: { xs: '1.2rem', md: '1rem' },
             }
         }
     };
@@ -427,8 +445,8 @@ const Chat: React.FC<IChatProps> = ({
                                 style: { fontSize: '1em' },
                                 endAdornment: (
                                     <InputAdornment position="end" sx={{ ml: 0, p: 0 }}>
-                                        <IconButton size="small" onClick={handleChatSubmit}>
-                                            <Send sx={{ color: '#fff', fontSize: '1.1em' }} />
+                                        <IconButton sx={styles.sendButton} onClick={handleChatSubmit}>
+                                            <Send sx={styles.sendIcon} />
                                         </IconButton>
                                     </InputAdornment>
                                 ),

--- a/src/app/_components/_sharedcomponents/Chat/Chat.tsx
+++ b/src/app/_components/_sharedcomponents/Chat/Chat.tsx
@@ -308,6 +308,12 @@ const Chat: React.FC<IChatProps> = ({
             backgroundColor: '#28282800',
             flex: 1,
         },
+        chatMessageStack: {
+            minHeight: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'flex-end',
+        },
         messageText: {
             fontSize: { xs: '0.75em', md: '1em' },
             color: '#fff',
@@ -387,10 +393,12 @@ const Chat: React.FC<IChatProps> = ({
     return (
         <>
             <Box sx={styles.chatBox}>
-                {chatHistory && chatHistory.map((chatEntry: IChatEntry, index: number) => {
-                    return formatMessage(chatEntry?.message, index);
-                })}
-                <Box ref={chatEndRef} />
+                <Box sx={styles.chatMessageStack}>
+                    {chatHistory && chatHistory.map((chatEntry: IChatEntry, index: number) => {
+                        return formatMessage(chatEntry?.message, index);
+                    })}
+                    <Box ref={chatEndRef} />
+                </Box>
             </Box>
 
             {opponentIsTyping && (

--- a/src/app/_components/_sharedcomponents/Chat/Chat.tsx
+++ b/src/app/_components/_sharedcomponents/Chat/Chat.tsx
@@ -353,13 +353,17 @@ const Chat: React.FC<IChatProps> = ({
             maxWidth: '100%',
             minWidth: 0,
             width: '100%',
-            fontSize: { xs: '1rem', md: '1em' },
+            fontSize: { xs: '16px', md: '1em' },
             height: { xs: '44px', md: '2.2rem' },
             input: {
                 color: '#fff',
+                fontSize: { xs: '16px', md: '1em' },
                 padding: { xs: '0 0.5rem', md: '0.3em 0.5em' },
                 height: { xs: '44px', md: 'auto' },
                 boxSizing: 'border-box',
+            },
+            '& .MuiInputBase-input': {
+                fontSize: { xs: '16px', md: '1em' },
             },
             '& .MuiOutlinedInput-root': {
                 height: { xs: '44px', md: '2.2rem' },
@@ -450,6 +454,9 @@ const Chat: React.FC<IChatProps> = ({
                                         </IconButton>
                                     </InputAdornment>
                                 ),
+                            },
+                            htmlInput: {
+                                style: { fontSize: '16px' },
                             },
                         }}
                     />

--- a/src/app/_components/_sharedcomponents/Chat/Chat.tsx
+++ b/src/app/_components/_sharedcomponents/Chat/Chat.tsx
@@ -1,12 +1,12 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
     Box,
     TextField,
     IconButton,
     InputAdornment,
-    Typography, Collapse,
+    Typography,
 } from '@mui/material';
-import { CommentsDisabled, ExpandLess, ExpandMore, Send, ReportProblem } from '@mui/icons-material';
+import { Send } from '@mui/icons-material';
 import { 
     IChatProps, 
     IChatEntry, 
@@ -21,10 +21,6 @@ import { useSoundHandler } from '@/app/_hooks/useSoundHandler';
 import { useUser } from '@/app/_contexts/User.context';
 import { getMuteDisplayText } from '@/app/_utils/ModerationUtils';
 import { ChatDisabledReason, IChatDisabledInfo } from '@/app/_contexts/UserTypes';
-import {
-    LobbyConfirmationPopupModule
-} from '@/app/_components/Lobby/_subcomponents/LobbyConfirmationPopup/LobbyConfirmationPopup';
-import PlayerReportDialog from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PlayerReportDialog';
 import { ILobbyUserProps } from '../../Lobby/LobbyTypes';
 import { MatchmakingType } from '@/app/_constants/constants';
 import RichText from '../RichText/RichText';
@@ -35,14 +31,10 @@ const Chat: React.FC<IChatProps> = ({
     handleChatOnChange,
     handleChatSubmit,
 }) => {
-    const { lobbyState, connectedPlayer, isSpectator, getOpponent, isAnonymousPlayer, hasChatDisabled, sendLobbyMessage } = useGame();
-    const [showConfirmation, setShowConfirmation] = useState(false);
-    const [playerReportOpen, setPlayerReportOpen] = useState(false);
+    const { lobbyState, connectedPlayer, isSpectator, getOpponent, isAnonymousPlayer, hasChatDisabled } = useGame();
     const chatEndRef = useRef<HTMLDivElement | null>(null);
     const previousMessagesRef = useRef<IChatEntry[]>([]);
     const { user } = useUser();
-
-    const [isOptionsOpen, setIsOptionsOpen] = useState(false);
 
     // Initialize sound handler with user preferences
     const { playIncomingMessageSound } = useSoundHandler({
@@ -114,7 +106,6 @@ const Chat: React.FC<IChatProps> = ({
     const chatDisabledInfo = getChatDisabledInfo();
     // Helper function to determine if chat input should be shown
     const shouldShowChatInput = !chatDisabledInfo || chatDisabledInfo.reason === ChatDisabledReason.None;
-    const canReportOpponent = !isAnonymousPlayer(connectedPlayer) && (!!opponentId && !isAnonymousOpponent);
     const opponentIsTyping = lobbyState?.gameChat.typingState[opponentId];
 
     const getSpectatorDisplayName = (
@@ -126,29 +117,6 @@ const Chat: React.FC<IChatProps> = ({
         if (playerId === getOpponent(connectedPlayer)) return 'Player 2';
         return 'Unknown Player';
     };
-
-    const triggerDisableConfirmation = () =>{
-        setShowConfirmation(true);
-        setIsOptionsOpen(false);
-    }
-
-    const handleConfirmDisableChat = () => {
-        sendLobbyMessage(['muteChat']);
-        setShowConfirmation(false);
-    };
-
-    const handleCancelDisableChat = () => {
-        setShowConfirmation(false);
-    };
-
-    const handleOpenPersonReport = () => {
-        setPlayerReportOpen(true);
-    };
-
-    const handleClosePersonReport = () => {
-        setPlayerReportOpen(false);
-    };
-
 
     const isOpponentMessage = (message: IChatMessageContent | undefined, connectedPlayerId: string): boolean => {
         if (!message) return false;
@@ -333,67 +301,6 @@ const Chat: React.FC<IChatProps> = ({
     // ------------------------STYLES------------------------//
 
     const styles = {
-        headerContainer: {
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            px: '0.5em',
-            py: '0.25em',
-            backgroundColor: '#28282800',
-            cursor: 'pointer',
-            transition: 'background-color 0.2s ease',
-        },
-        headerTitle: {
-            fontSize: { xs: '0.85em', md: '1em' },
-            color: '#fff',
-            fontWeight: 'bold',
-        },
-        expandIcon: {
-            color: '#fff',
-            fontSize: '1.2em',
-            transition: 'transform 0.2s ease',
-        },
-        optionsPanel: {
-            backgroundColor: '#1a1a1a',
-            borderBottom: '1px solid',
-            borderColor: '#FFFE5031',
-        },
-        optionItem: {
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            px: '1em',
-            py: '0.5em',
-            cursor: 'pointer',
-            background: 'linear-gradient(#1E2D32, #1E2D32) padding-box',
-            '&:hover': {
-                background: 'linear-gradient(#2C4046, #2C4046) padding-box',
-            },
-            transition: 'background 0.2s ease',
-        },
-        optionLabel: {
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px',
-            color: '#fff',
-            fontSize: { xs: '0.8em', md: '0.9em' },
-        },
-        optionIcon: {
-            color: '#fff',
-            fontSize: '1.1em',
-        },
-        optionStatus: {
-            fontSize: { xs: '0.7em', md: '0.8em' },
-            color: '#888',
-            textTransform: 'uppercase',
-        },
-        mutedIndicator: {
-            fontSize: { xs: '0.7em', md: '0.8em' },
-            color: '#ffa726',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '4px',
-        },
         chatBox: {
             p: '0.5em',
             minHeight: '100px',
@@ -479,80 +386,6 @@ const Chat: React.FC<IChatProps> = ({
 
     return (
         <>
-            {/* Chat Header - Clickable to expand options */}
-            {!isSpectator && (<Box
-                sx={styles.headerContainer}
-                onClick={!isSpectator ? () => setIsOptionsOpen(!isOptionsOpen) : undefined}
-            >
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <Typography sx={styles.headerTitle}>Chat Options</Typography>
-                </Box>
-                {!isSpectator && (
-                    isOptionsOpen ? (
-                        <ExpandLess sx={styles.expandIcon} />
-                    ) : (
-                        <ExpandMore sx={styles.expandIcon} />
-                    )
-                )}
-            </Box>)}
-
-            {/* Collapsible Options Panel */}
-            {!isSpectator && (
-                <Collapse in={isOptionsOpen}>
-                    <Box sx={styles.optionsPanel}>
-                        {shouldShowChatInput && (
-                            <>
-                                <Box sx={styles.optionItem} onClick={triggerDisableConfirmation}>
-                                    <Box sx={styles.optionLabel}>
-                                        <CommentsDisabled sx={styles.optionIcon} />
-                                        <span>Disable Chat</span>
-                                    </Box>
-                                </Box>
-                                {canReportOpponent && (
-                                    <Box
-                                        sx={{
-                                            ...styles.optionItem,
-                                            ...(user?.reportingDisabled ? { opacity: 0.5, cursor: 'default', '&:hover': {} } : {})
-                                        }}
-                                        onClick={user?.reportingDisabled ? undefined : handleOpenPersonReport}
-                                    >
-                                        <Box sx={styles.optionLabel}>
-                                            <ReportProblem sx={styles.optionIcon} />
-                                            <span>{user?.reportingDisabled ? 'Reporting disabled' : 'Report Opponent'}</span>
-                                        </Box>
-                                    </Box>
-                                )}
-                            </>
-                        )}
-                        {!shouldShowChatInput && (
-                            <>
-                                <Box sx={{ ...styles.optionItem, cursor: 'default', '&:hover': {} }}>
-                                    <Box sx={styles.optionLabel}>
-                                        <CommentsDisabled sx={styles.optionIcon} />
-                                        <span style={{ color: '#888' }}>
-                                            Chat is disabled
-                                        </span>
-                                    </Box>
-                                </Box>
-                                {canReportOpponent && (
-                                    <Box
-                                        sx={{
-                                            ...styles.optionItem,
-                                            ...(user?.reportingDisabled ? { opacity: 0.5, cursor: 'default', '&:hover': {} } : {})
-                                        }}
-                                        onClick={user?.reportingDisabled ? undefined : handleOpenPersonReport}
-                                    >
-                                        <Box sx={styles.optionLabel}>
-                                            <ReportProblem sx={styles.optionIcon} />
-                                            <span>{user?.reportingDisabled ? 'Reporting disabled' : 'Report Opponent'}</span>
-                                        </Box>
-                                    </Box>
-                                )}
-                            </>
-                        )}
-                    </Box>
-                </Collapse>
-            )}
             <Box sx={styles.chatBox}>
                 {chatHistory && chatHistory.map((chatEntry: IChatEntry, index: number) => {
                     return formatMessage(chatEntry?.message, index);
@@ -601,8 +434,6 @@ const Chat: React.FC<IChatProps> = ({
                     </Typography>
                 )}
             </Box>
-            <LobbyConfirmationPopupModule title={'Disable Chat Confirmation'} message={'Are you sure you wish to disable chat for this game? This action is not reversable.'} display={showConfirmation} onConfirmation={handleConfirmDisableChat} handleCancel={handleCancelDisableChat}/>
-            <PlayerReportDialog open={playerReportOpen} onClose={handleClosePersonReport}/>
         </>
 
     );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 // layout.tsx
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import React from 'react';
 import ClientLayout from './ClientLayout';
 import { Barlow, Barlow_Semi_Condensed } from 'next/font/google';
@@ -19,6 +19,11 @@ const barlowSemiCondensed = Barlow_Semi_Condensed({
 
 export const metadata: Metadata = {
     title: 'Karabast',
+};
+
+export const viewport: Viewport = {
+    width: 'device-width',
+    initialScale: 1,
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Changes

- Moved "Leave Game" and "Preferences" button from board to Chat Drawer
- Use `SwipeableDrawer` on mobile devices for better mobile UX 
- set `initialScale=1` to avoid device zoom in when changing device orientation 
- Font size on chat input is `16px` to avoid zoom in on mobile browsers.
- Fix chat input size to meet Material Design standards on mobile
- Chat text now grows from bottom to top like other chats.
- Group not so often actions into an ellipsis menu in the drawer
- Make tray buttons bigger on mobile
- Add a hint when SwipeableDrawer is closed so the user knows it's hidden.
 
## Rationale

`SwipeableDrawer` makes a much better UX mobile usability but it's hard to use when having buttons to the right of the board. In addition "Leave game" and "preferences" are taking screen space which could be useful to avoid last played card shrinkage on mobile and they are not necessary on screen while playing.    

## Mobile UI

https://github.com/user-attachments/assets/a9108d86-80bd-4d3d-9c96-4ade88290cf6

## Swipeable drawer hint addition


https://github.com/user-attachments/assets/a9bd8070-3827-4a35-af9d-69a078b125c3


## Desktop: preferences & exit to chat drawer

<img width="1678" height="896" alt="Screenshot 2026-07-06 at 1 53 39 PM" src="https://github.com/user-attachments/assets/ea54df2f-68e5-4c70-90a1-11aabd903d8a" />

<img width="1677" height="895" alt="Screenshot 2026-07-06 at 1 53 52 PM" src="https://github.com/user-attachments/assets/f53f12ce-be89-44ad-b841-2f49de6bda4e" />


