### PR TITLE
Update home banners to ash set images

### DIFF
--- a/src/app/_components/_sharedcomponents/Banner/Banner.tsx
+++ b/src/app/_components/_sharedcomponents/Banner/Banner.tsx
@@ -56,18 +56,18 @@ const KarabastBanner: React.FC = () => {
             flex: 1,
         },
         block1: {
-            backgroundImage: `url(${s3ImageURL('ui/law-vader-banner.webp')})`,
+            backgroundImage: `url(${s3ImageURL('ui/ash-luke-banner.webp')})`,
             marginRight: { xs: '-7px', md: '-152px' },
         },
         block2: {
-            backgroundImage: `url(${s3ImageURL('ui/law-leia-banner.webp')})`,
+            backgroundImage: `url(${s3ImageURL('ui/ash-palp-banner.webp')})`,
         },
         block3: {
-            backgroundImage: `url(${s3ImageURL('ui/law-jabba-banner.webp')})`,
+            backgroundImage: `url(${s3ImageURL('ui/ash-mando-banner.webp')})`,
             marginLeft: { xs: '-7px', md: '-152px' },
         },
         block4: {
-            backgroundImage: `url(${s3ImageURL('ui/law-enfys-banner.webp')})`,
+            backgroundImage: `url(${s3ImageURL('ui/ash-cad-banner.webp')})`,
             marginLeft: { xs: '-7px', md: '-152px' },
         },
     };


### PR DESCRIPTION
Swaps the four home-page banner images from the `law-*` set to the new `ash-*` set (luke, palp, mando, cad), served from the existing S3 bucket via `s3ImageURL`.

## Changes
- `block1`: `law-vader` → `ash-luke`
- `block2`: `law-leia` → `ash-palp`
- `block3`: `law-jabba` → `ash-mando`
- `block4`: `law-enfys` → `ash-cad`

All four `ui/ash-*-banner.webp` assets are confirmed live in the S3 bucket (200, image/webp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)