### PR TITLE
Fix Niamos deck import: recognize niamos.net URLs and stop null-deck POST

### DIFF
--- a/src/app/_components/_sharedcomponents/CreateGameForm/CreateGameForm.tsx
+++ b/src/app/_components/_sharedcomponents/CreateGameForm/CreateGameForm.tsx
@@ -199,6 +199,13 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
                     'Incorrect deck format or unsupported deckbuilder.',
                     'Deck Validation Error','error');
                 setModalOpen(true);
+                // Bail out here: without this return, execution falls through to
+                // the create-lobby POST below with deckData still null, so the
+                // clear client-side validation error above gets clobbered by a
+                // confusing server 400 ("No deck or swudbLink provided"). The
+                // other deck-entry forms (DeckSelectionCard, QuickGameForm)
+                // already return in this branch.
+                return;
             }
         }catch (error){
             clearErrors();

--- a/src/app/_utils/checkJson.ts
+++ b/src/app/_utils/checkJson.ts
@@ -225,6 +225,7 @@ export const parseInputAsDeckData = (input: string): {
         input.includes('kyberdecks.com') ||
         input.includes('cardcore.gg') ||
         input.includes('holoscan.net') ||
+        input.includes('niamos.net') ||
         input.includes('melee.gg')
     ) {
         return { type: 'url', data: null };


### PR DESCRIPTION
parseInputAsDeckData in checkJson.ts had a hardcoded host allowlist that was never updated when NiamosDeckProvider was added, so niamos.net links were classified as 'invalid' before fetchDeckData ran. In CreateGameForm the invalid-branch fell through (no return) and POSTed create-lobby with deck: null, producing the server's 400 'No deck or swudbLink provided'.

- Add niamos.net to the parseInputAsDeckData allowlist.
- Return from CreateGameForm's invalid-deck branch like the other two forms.