### PR TITLE
Feature: Adding SWUPedia to the list of supported deckbuilders

### DIFF
--- a/src/app/_utils/checkJson.ts
+++ b/src/app/_utils/checkJson.ts
@@ -226,6 +226,7 @@ export const parseInputAsDeckData = (input: string): {
         input.includes('cardcore.gg') ||
         input.includes('holoscan.net') ||
         input.includes('niamos.net') ||
+        input.includes('swupedia.com') ||
         input.includes('melee.gg')
     ) {
         return { type: 'url', data: null };

--- a/src/app/_utils/deckProviders/SwupediaDeckProvider.ts
+++ b/src/app/_utils/deckProviders/SwupediaDeckProvider.ts
@@ -1,0 +1,27 @@
+import { DeckSource } from '../deckTypes';
+import { DeckProviderBase, IStatusErrorOverride } from './core/DeckProviderBase';
+import { DeckFetchErrorReason } from './core/types';
+
+export class SwupediaDeckProvider extends DeckProviderBase {
+    public override readonly source = DeckSource.SWUPedia;
+    public override readonly displayName = 'swupedia.com';
+    public override readonly hostNameMatch = 'swupedia.com';
+    public override readonly tagColor = '#615FFF';
+    public override readonly hiddenFromPublicList = false;
+    protected override readonly deckIdRegex = /\/deck\/([2-9A-HJ-NP-Za-km-z]{12})(?=\/|\?|#|$)/;
+
+    protected override readonly statusErrorOverrides: Partial<Record<number, IStatusErrorOverride>> = {
+        404: {
+            reason: DeckFetchErrorReason.NotFound,
+            message: 'Deck not found. Make sure it is set to Unlisted (and NOT Private) on SWUPedia.com',
+        },
+        422: {
+            reason: DeckFetchErrorReason.ProviderError,
+            message: 'SWUPedia could not return a valid Karabast deck. Please check if your deck contains valid entries.'
+        }
+    };
+
+    protected override buildApiUrl(deckId: string): string {
+        return `https://swupedia.com/deck/${deckId}/karabast`;
+    }
+}

--- a/src/app/_utils/deckProviders/core/registry.ts
+++ b/src/app/_utils/deckProviders/core/registry.ts
@@ -15,6 +15,7 @@ import { SwuforgeDeckProvider } from '../SwuforgeDeckProvider';
 import { SwumetastatsDeckProvider } from '../SwumetastatsDeckProvider';
 import { SwUnlimitedDbDeckProvider } from '../SwUnlimitedDbDeckProvider';
 import { SwustatsDeckProvider } from '../SwustatsDeckProvider';
+import { SwupediaDeckProvider } from '../SwupediaDeckProvider';
 import { buildTagStyle } from './tagStyle';
 import { DeckFetchError, DeckFetchErrorReason } from './types';
 
@@ -45,6 +46,7 @@ const providers: readonly DeckProviderBase[] = [
     new KyberdecksDeckProvider(),
     new CardcoreDeckProvider(),
     new HoloscanDeckProvider(),
+    new SwupediaDeckProvider(),
 ];
 
 /**

--- a/src/app/_utils/deckTypes.ts
+++ b/src/app/_utils/deckTypes.ts
@@ -31,7 +31,8 @@ export enum DeckSource {
     CardCore = 'CardCore',
     HoloScan = 'HoloScan',
     Melee = 'Melee',
-    Niamos = 'Niamos'
+    Niamos = 'Niamos',
+    SWUPedia = 'SWUPedia'
 }
 
 export interface IDeckData {


### PR DESCRIPTION
Includes swupedia.com as a list of supported deckbuilders.

Proof:
<img width="1512" height="815" alt="image" src="https://github.com/user-attachments/assets/c89b30b3-8722-482f-b0a2-da5bf8bbc2d0" />
<img width="1512" height="685" alt="image" src="https://github.com/user-attachments/assets/23972d5d-cdda-4c2c-a3c4-c568af3d10c6" />
