### PR TITLE
Add game-ended modal and drawer actions

### DIFF
--- a/src/app/GameBoard/page.tsx
+++ b/src/app/GameBoard/page.tsx
@@ -9,6 +9,7 @@ import PlayerCardTray from '../_components/Gameboard/PlayerCardTray/PlayerCardTr
 import { useGame } from '../_contexts/Game.context';
 import PopupShell from '../_components/_sharedcomponents/Popup/Popup';
 import PreferencesComponent from '@/app/_components/_sharedcomponents/Preferences/PreferencesComponent';
+import GameEndedModal from '@/app/_components/Gameboard/_subcomponents/Overlays/GameEndedModal/GameEndedModal';
 import { useRouter } from 'next/navigation';
 import { Bo3SetEndedReason, GamesToWinMode, IBo3SetEndResult, MatchmakingType } from '@/app/_constants/constants';
 import { s3ImageURL } from '@/app/_utils/s3Utils';
@@ -20,6 +21,7 @@ const GameBoard = () => {
     const sidebarState = localStorage.getItem('sidebarState') !== null ? localStorage.getItem('sidebarState') === 'true' : true;
     const [sidebarOpen, setSidebarOpen] = useState(sidebarState);
     const [isPreferenceOpen, setPreferenceOpen] = useState(false);
+    const [isGameEndedModalOpen, setGameEndedModalOpen] = useState(false);
     const [userClosedWinScreen, setUserClosedWinScreen] = useState(false);
     const user = gameState?.players[connectedPlayer]?.user;
     const backgroundPath = (isSpectator ? undefined : user?.cosmetics?.background?.path) ?? s3ImageURL('ui/board-background-1.webp');
@@ -38,11 +40,13 @@ const GameBoard = () => {
 
     useEffect(() => {
         const hasWinners = !!gameState?.winners.length;
-        // open preferences automatically if game ended and user hasn't closed it themselves yet.
+        // Show the game-ended actions once per completed game.
         if (hasWinners && !userClosedWinScreen) {
-            setPreferenceOpen(true);
+            setPreferenceOpen(false);
+            setGameEndedModalOpen(true);
         } else if (!hasWinners && userClosedWinScreen) {
             setUserClosedWinScreen(false);
+            setGameEndedModalOpen(false);
         }
     }, [gameState?.winners, userClosedWinScreen]);
 
@@ -52,10 +56,12 @@ const GameBoard = () => {
     }
 
     const handlePreferenceToggle = () => {
-        if(!!gameState?.winners.length) {
-            setUserClosedWinScreen(true);
-        }
         setPreferenceOpen(!isPreferenceOpen);
+    };
+
+    const handleGameEndedModalClose = () => {
+        setUserClosedWinScreen(true);
+        setGameEndedModalOpen(false);
     };
 
     // check if game ended already.
@@ -64,7 +70,7 @@ const GameBoard = () => {
     // we set tabs
     // ['endGame','keyboardShortcuts','cardSleeves','gameOptions']
     const preferenceTabs = winners
-        ? ['endGame','soundOptions','gameOptions']
+        ? ['soundOptions','gameOptions']
         : ['currentGame','soundOptions','gameOptions'];
 
     // Get game number from winHistory for Bo3 mode
@@ -188,16 +194,24 @@ const GameBoard = () => {
                 sidebarOpen={sidebarOpen}
                 toggleSidebar={toggleSidebar}
                 preferenceToggle={handlePreferenceToggle}
+                openGameEndedModal={() => setGameEndedModalOpen(true)}
             />
 
             <PopupShell sidebarOpen={sidebarOpen}/>
+            {winners && (
+                <GameEndedModal
+                    open={isGameEndedModalOpen}
+                    onClose={handleGameEndedModalClose}
+                    title={gameEndedTitle}
+                    subtitle={winners.length > 1 ? 'Game ended in a draw' : `Winner is ${getWinnerDisplayName(winners[0])}`}
+                />
+            )}
             {isPreferenceOpen && <PreferencesComponent
                 sidebarOpen={sidebarOpen}
                 isPreferenceOpen={isPreferenceOpen}
                 preferenceToggle={handlePreferenceToggle}
                 tabs={preferenceTabs}
-                title={winners ? gameEndedTitle : 'PREFERENCES'}
-                subtitle={winners ? winners.length > 1 ? 'Game ended in a draw' : `Winner is ${getWinnerDisplayName(winners[0])}` : undefined}
+                title="PREFERENCES"
             />}
         </Grid>
     );

--- a/src/app/_components/Gameboard/GameboardTypes.ts
+++ b/src/app/_components/Gameboard/GameboardTypes.ts
@@ -16,6 +16,7 @@ export interface IChatDrawerProps {
     sidebarOpen: boolean;
     toggleSidebar: () => void;
     preferenceToggle: () => void;
+    openGameEndedModal: () => void;
 }
 
 export interface IPlayerCardTrayProps {

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -4,11 +4,11 @@ import {
     Box,
     Button,
     IconButton,
-    Divider,
     Menu,
     MenuItem,
     ListItemIcon,
     ListItemText,
+    Snackbar,
     Tooltip,
     useMediaQuery,
     useTheme,
@@ -22,20 +22,18 @@ import BlockIcon from '@mui/icons-material/Block';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import LogoutIcon from '@mui/icons-material/Logout';
-import OutlinedFlagIcon from '@mui/icons-material/OutlinedFlag';
 import CommentsDisabledIcon from '@mui/icons-material/CommentsDisabled';
 import ReportProblemIcon from '@mui/icons-material/ReportProblem';
+import LinkIcon from '@mui/icons-material/Link';
+import BugReportIcon from '@mui/icons-material/BugReport';
 import { MatchmakingType, QuickUndoAvailableState } from '@/app/_constants/constants';
 import { useChatTypingState } from '@/app/_hooks/useChatTypingState';
-import { usePopup } from '@/app/_contexts/Popup.context';
-import { PopupSource } from '@/app/_components/_sharedcomponents/Popup/Popup.types';
-import { v4 as uuidv4 } from 'uuid';
-import { useRouter } from 'next/navigation';
 import { useUser } from '@/app/_contexts/User.context';
 import { ChatDisabledReason, IChatDisabledInfo } from '@/app/_contexts/UserTypes';
 import { getMuteDisplayText } from '@/app/_utils/ModerationUtils';
 import { LobbyConfirmationPopupModule } from '@/app/_components/Lobby/_subcomponents/LobbyConfirmationPopup/LobbyConfirmationPopup';
 import PlayerReportDialog from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PlayerReportDialog';
+import BugReportDialog from '@/app/_components/_sharedcomponents/Preferences/_subComponents/BugReportDialog';
 import { Theme } from '@mui/material/styles';
 
 // ------------------------STYLES------------------------//
@@ -120,7 +118,7 @@ const styles = {
     headerActionsStyle: {
         display: 'flex',
         alignItems: 'center',
-        gap: '0.5rem',
+        gap: '0.35rem',
         ml: 'auto',
     },
     drawerActionButton: {
@@ -153,6 +151,9 @@ const styles = {
             marginLeft: 0,
             marginRight: '6px',
         },
+    },
+    headerCircularButton: {
+        padding: '8px',
     },
     quickUndoButtonEnabled: {
         borderColor: 'rgba(255, 255, 255, 0.12)',
@@ -275,7 +276,7 @@ const UndoButton = ({ disabledOverride = false }: { disabledOverride?: boolean }
     )
 }
 
-const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, preferenceToggle }) => {
+const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, preferenceToggle, openGameEndedModal }) => {
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
     const {
@@ -294,11 +295,11 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
     const [chatMessage, setChatMessage] = useState('')
     const [menuAnchorElement, setMenuAnchorElement] = useState<null | HTMLElement>(null);
     const [showDisableChatConfirmation, setShowDisableChatConfirmation] = useState(false);
-    const [showConcedeConfirmation, setShowConcedeConfirmation] = useState(false);
+    const [showEndGameConfirmation, setShowEndGameConfirmation] = useState(false);
     const [playerReportOpen, setPlayerReportOpen] = useState(false);
-    const { openPopup } = usePopup();
+    const [bugReportOpen, setBugReportOpen] = useState(false);
+    const [shareLinkCopied, setShareLinkCopied] = useState(false);
     const { user } = useUser();
-    const router = useRouter();
     const isDev = process.env.NODE_ENV === 'development';
     const isUndoEnabled = isDev || gameState.undoEnabled;
     const shouldShowUndo = !isSpectator;
@@ -311,6 +312,9 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
     const opponentChatDisabled = hasChatDisabled(opponentId);
     const canReportOpponent = !isSpectator && !isAnonymousPlayer(connectedPlayer) && (!!opponentId && !isAnonymousOpponent);
     const isReportingDisabled = !!user?.reportingDisabled;
+    const canReportBug = !isAnonymousPlayer(connectedPlayer);
+    const canShareGameLink = !isSpectator && !!lobbyState?.settings?.allowSpectators && !!lobbyState?.spectateLink;
+    const hasGameEnded = !!gameState.winners?.length;
 
     const getChatDisabledInfo = (): IChatDisabledInfo => {
         if (isPrivateLobby && !doesUserHaveChatMuted) {
@@ -402,33 +406,24 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
         preferenceToggle();
     }
 
-    const handleLeaveGameClick = () => {
+    const handleEndGameClick = () => {
         handleMenuClose();
         closeMobileDrawer();
-        if (isSpectator){
-            router.push('/');
+        if (hasGameEnded) {
+            openGameEndedModal();
         } else {
-            openPopup('leaveGame', {
-                uuid: `${uuidv4()}`,
-                source: PopupSource.User
-            });
+            setShowEndGameConfirmation(true);
         }
     }
 
-    const handleConcedeClick = () => {
-        handleMenuClose();
-        closeMobileDrawer();
-        setShowConcedeConfirmation(true);
-    }
-
-    const handleConfirmConcede = () => {
+    const handleConfirmEndGame = () => {
         const playerName = gameState.players[connectedPlayer]?.name;
         sendGameMessage(['concede', playerName]);
-        setShowConcedeConfirmation(false);
+        setShowEndGameConfirmation(false);
     };
 
-    const handleCancelConcede = () => {
-        setShowConcedeConfirmation(false);
+    const handleCancelEndGame = () => {
+        setShowEndGameConfirmation(false);
     };
 
     const handleDisableChatClick = () => {
@@ -456,18 +451,52 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
         setPlayerReportOpen(false);
     };
 
+    const handleShareGameLink = async () => {
+        const spectateLink = lobbyState?.spectateLink;
+        if (!spectateLink) return;
+
+        handleMenuClose();
+        closeMobileDrawer();
+        try {
+            await navigator.clipboard.writeText(spectateLink);
+            setShareLinkCopied(true);
+        } catch (error) {
+            console.error('Failed to copy spectate link', error);
+        }
+    };
+
+    const handleOpenBugReport = () => {
+        handleMenuClose();
+        closeMobileDrawer();
+        setBugReportOpen(true);
+        sendGameMessage(['resetActionTimer']);
+    };
+
     const drawerContent = (
         <>
             <Box sx={styles.headerBoxStyle}>
+                {shouldShowUndo && (<UndoButton disabledOverride={!isUndoEnabled} />)}
                 <Box sx={styles.headerActionsStyle}>
-                    {shouldShowUndo && (<UndoButton disabledOverride={!isUndoEnabled} />)}
+                    {!isSpectator && (
+                        <Tooltip title="End game">
+                            <span>
+                                <IconButton
+                                    aria-label="End game"
+                                    onClick={handleEndGameClick}
+                                    sx={[styles.drawerActionButton, styles.headerCircularButton]}
+                                >
+                                    <LogoutIcon />
+                                </IconButton>
+                            </span>
+                        </Tooltip>
+                    )}
                     <IconButton
                         aria-label="game menu"
                         aria-controls={isMenuOpen ? 'chat-drawer-game-menu' : undefined}
                         aria-haspopup="true"
                         aria-expanded={isMenuOpen ? 'true' : undefined}
                         onClick={handleMenuOpen}
-                        sx={styles.drawerActionButton}
+                        sx={[styles.drawerActionButton, styles.headerCircularButton]}
                     >
                         <MoreHorizIcon />
                     </IconButton>
@@ -492,6 +521,20 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
                                 <ListItemText>{shouldShowChatInput ? 'Disable chat' : 'Chat is disabled'}</ListItemText>
                             </MenuItem>
                         )}
+                        {!isSpectator && (
+                            <MenuItem disabled={!canShareGameLink} onClick={handleShareGameLink}>
+                                <ListItemIcon sx={styles.menuIcon}>
+                                    <LinkIcon fontSize="small" />
+                                </ListItemIcon>
+                                <ListItemText>Share game link</ListItemText>
+                            </MenuItem>
+                        )}
+                        <MenuItem disabled={!canReportBug || isReportingDisabled} onClick={handleOpenBugReport}>
+                            <ListItemIcon sx={styles.menuIcon}>
+                                <BugReportIcon fontSize="small" />
+                            </ListItemIcon>
+                            <ListItemText>{isReportingDisabled ? 'Reporting disabled' : 'Report Bug'}</ListItemText>
+                        </MenuItem>
                         {!isSpectator && canReportOpponent && (
                             <MenuItem disabled={isReportingDisabled} onClick={handleOpenPlayerReport}>
                                 <ListItemIcon sx={styles.menuIcon}>
@@ -500,21 +543,6 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
                                 <ListItemText>{isReportingDisabled ? 'Reporting disabled' : 'Report Opponent'}</ListItemText>
                             </MenuItem>
                         )}
-                        <Divider sx={{ borderColor: 'rgba(255, 255, 255, 0.14)' }} />
-                        {!isSpectator && (
-                            <MenuItem onClick={handleConcedeClick}>
-                                <ListItemIcon sx={styles.menuIcon}>
-                                    <OutlinedFlagIcon fontSize="small" />
-                                </ListItemIcon>
-                                <ListItemText>Concede game</ListItemText>
-                            </MenuItem>
-                        )}
-                        <MenuItem onClick={handleLeaveGameClick}>
-                            <ListItemIcon sx={styles.menuIcon}>
-                                <LogoutIcon fontSize="small" />
-                            </ListItemIcon>
-                            <ListItemText>Leave game</ListItemText>
-                        </MenuItem>
                     </Menu>
                 </Box>
             </Box>
@@ -528,9 +556,16 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
                 handleChatSubmit={handleGameChat}
             />
 
-            <LobbyConfirmationPopupModule title={'Concede Game Confirmation'} message={'Are you sure you wish to concede? This game will count as a loss.'} display={showConcedeConfirmation} onConfirmation={handleConfirmConcede} handleCancel={handleCancelConcede}/>
+            <LobbyConfirmationPopupModule title={'Do you want to end the game?'} message={'This will concede the game to your opponent and count as a loss.'} display={showEndGameConfirmation} onConfirmation={handleConfirmEndGame} handleCancel={handleCancelEndGame}/>
             <LobbyConfirmationPopupModule title={'Disable Chat Confirmation'} message={'Are you sure you wish to disable chat for this game? This action is not reversable.'} display={showDisableChatConfirmation} onConfirmation={handleConfirmDisableChat} handleCancel={handleCancelDisableChat}/>
             <PlayerReportDialog open={playerReportOpen} onClose={handleClosePlayerReport}/>
+            <BugReportDialog open={bugReportOpen} onClose={() => setBugReportOpen(false)}/>
+            <Snackbar
+                open={shareLinkCopied}
+                autoHideDuration={2000}
+                onClose={() => setShareLinkCopied(false)}
+                message="Game link copied"
+            />
         </>
     );
 

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -526,7 +526,7 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
                                 <ListItemIcon sx={styles.menuIcon}>
                                     <LinkIcon fontSize="small" />
                                 </ListItemIcon>
-                                <ListItemText>Share game link</ListItemText>
+                                <ListItemText>Share spectator link</ListItemText>
                             </MenuItem>
                         )}
                         <MenuItem disabled={!canReportBug || isReportingDisabled} onClick={handleOpenBugReport}>

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/GameEndedModal/GameEndedModal.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/GameEndedModal/GameEndedModal.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {
+    Dialog,
+    DialogContent,
+    DialogTitle,
+    IconButton,
+    Typography,
+} from '@mui/material';
+import CloseOutlinedIcon from '@mui/icons-material/CloseOutlined';
+import EndGameTab from '@/app/_components/_sharedcomponents/Preferences/PreferencesSubElementVariants/EndGameTab';
+
+interface IGameEndedModalProps {
+    open: boolean;
+    onClose: () => void;
+    title: string;
+    subtitle: string;
+}
+
+const GameEndedModal: React.FC<IGameEndedModalProps> = ({ open, onClose, title, subtitle }) => (
+    <Dialog
+        open={open}
+        onClose={onClose}
+        fullWidth
+        maxWidth="md"
+        aria-labelledby="game-ended-modal-title"
+        slotProps={{
+            paper: {
+                sx: {
+                    maxHeight: '90dvh',
+                    color: '#fff',
+                    backgroundColor: 'rgba(3, 12, 19, 0.96)',
+                    backgroundImage: 'linear-gradient(#0F1F27, #030C13)',
+                    border: '1px solid #50717D',
+                    borderRadius: '15px',
+                    backdropFilter: 'blur(30px)',
+                },
+            },
+            backdrop: {
+                sx: { backgroundColor: 'rgba(0, 0, 0, 0.65)' },
+            },
+        }}
+    >
+        <DialogTitle component="div" id="game-ended-modal-title" sx={{ textAlign: 'center', pr: '64px', pl: '64px' }}>
+            <Typography variant="h1">{title}</Typography>
+            <Typography variant="h2">{subtitle}</Typography>
+            <IconButton
+                aria-label="Close game ended modal"
+                onClick={onClose}
+                sx={{ position: 'absolute', right: '16px', top: '16px', color: '#fff' }}
+            >
+                <CloseOutlinedIcon />
+            </IconButton>
+        </DialogTitle>
+        <DialogContent dividers sx={{ px: { xs: '20px', sm: '30px' }, py: '30px' }}>
+            <EndGameTab />
+        </DialogContent>
+    </Dialog>
+);
+
+export default GameEndedModal;


### PR DESCRIPTION
## What changed

- Remove game actions from the preferences panel to its own modal (shown when game ends)
- Add while-in-game game actions to the ellipsis menu
- Add an end game button on the drawer as a single way to exit a game (inside the modal the user could exit to the main screen). 
- simplify the ellipsis menu by removing concede and leave-game

<img width="2734" height="1680" alt="feature" src="https://github.com/user-attachments/assets/7d540726-8d85-4308-a96a-f4370e16d9c2" />

<img width="2734" height="1680" alt="localhost_3000_GameBoard" src="https://github.com/user-attachments/assets/cc801c72-c0dc-4620-aa7f-8f7f4428262f" />

<img width="332" height="388" alt="Screenshot 2026-07-19 at 11 00 28 AM" src="https://github.com/user-attachments/assets/a62831cc-7fe0-410b-a44e-69899d628c58" />

## Why

Game actions were split between the preferences panel and the chat drawer, and completed games reused the full preferences interface. This gives end-of-game actions a focused surface and makes the most important in-game controls easier to reach.

Users told us they prefer a more reachable end game button so now it's always visible.
