### PR TITLE
Grouped-trigger resolution UI

### DIFF
--- a/src/app/_components/_sharedcomponents/Popup/Popup.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/Popup.tsx
@@ -2,9 +2,10 @@
 import { PopupData, PopupType, usePopup } from '@/app/_contexts/Popup.context';
 import { Box, SxProps, Theme } from '@mui/material';
 import React from 'react';
-import { ActionTriggerPopup, DefaultPopup, DropdownPopup, NumberPopup, PilePopup, SelectCardsPopup } from './Popup.types';
+import { ActionTriggerPopup, BatchTriggerPopup, DefaultPopup, DropdownPopup, NumberPopup, PilePopup, SelectCardsPopup } from './Popup.types';
 import { DefaultPopupModal } from './PopupVariant/DefaultPopup';
 import ActionTriggerPopupModal from './PopupVariant/ActionTriggerPopup';
+import BatchTriggerPopupModal from './PopupVariant/BatchTriggerPopup';
 import { PilePopupModal } from './PopupVariant/PilePopup';
 import { SelectCardsPopupModal } from './PopupVariant/SelectCardsPopup';
 import { contentStyle } from './Popup.styles';
@@ -74,6 +75,8 @@ const PopupShell: React.FC<IPopupShellProps> = ({
         switch (type) {
             case 'actionTrigger':
                 return <ActionTriggerPopupModal data={data as ActionTriggerPopup} />;
+            case 'batchTrigger':
+                return <BatchTriggerPopupModal data={data as BatchTriggerPopup} />;
             case 'default':
                 return <DefaultPopupModal data={data as DefaultPopup} />;
             case 'pile':
@@ -103,9 +106,10 @@ const PopupShell: React.FC<IPopupShellProps> = ({
         )
     }
 
+    const centeredModalTypes: PopupType[] = ['default', 'actionTrigger', 'batchTrigger'];
     const [nonDefaultPopups, defaultPopups] = [
-        popups.filter((popup) => popup.type !== 'default' && popup.type !== 'actionTrigger'),
-        popups.filter((popup) => popup.type === 'default' || popup.type === 'actionTrigger')
+        popups.filter((popup) => !centeredModalTypes.includes(popup.type)),
+        popups.filter((popup) => centeredModalTypes.includes(popup.type))
     ];
 
     const overlayStyle = {

--- a/src/app/_components/_sharedcomponents/Popup/Popup.types.ts
+++ b/src/app/_components/_sharedcomponents/Popup/Popup.types.ts
@@ -23,6 +23,8 @@ export type PopupButton = {
     hasLegalEffects?: boolean;
     selected?: boolean;
     disabled?: boolean;
+    // number of similar triggers this button represents when several are grouped into one choice
+    count?: number;
 };
 
 export type PerCardButton = {
@@ -45,6 +47,16 @@ export type ActionTriggerPopup = {
     uuid: string;
     title: string;
     description?: string;
+    buttons: PopupButton[];
+    source: PopupSource;
+};
+
+export type BatchTriggerPopup = {
+    type: 'batchTrigger';
+    uuid: string;
+    title: string;
+    sourceCard?: PopupSourceCard;
+    remainingCount: number;
     buttons: PopupButton[];
     source: PopupSource;
 };

--- a/src/app/_components/_sharedcomponents/Popup/PopupVariant/ActionTriggerPopup/TriggerButton.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/PopupVariant/ActionTriggerPopup/TriggerButton.tsx
@@ -8,16 +8,28 @@ import { CardStyle, CardType } from '@/app/_components/_sharedcomponents/Cards/C
 
 type SourceCardImageData = Parameters<typeof s3CardImageURL>[0];
 
+// vertical offset per stacked card; larger = more obvious stack. Kept in sync with the row's reserved
+// headroom (ACTION_TRIGGER_STACK_HEADROOM) so the upward peek + badge are never clipped.
+export const STACK_OFFSET_PX = 10;
+export const STACK_SCALE = 0.92; // scale factor for each stacked card; smaller = more obvious stack
+
 const styles = {
-    container: {
+    // the flex item. It is always exactly one card in size (same as an ungrouped trigger) so the row
+    // stays aligned; the stacked cards and count badge overflow upward beyond it without affecting layout.
+    wrapper: {
         position: 'relative',
-        isolation: 'isolate',
-        overflow: 'hidden',
-        aspectRatio: '1 / 1.4',
         // to avoid cutoff when doing the Y translation on hover effect
         mt: '1px',
         flex: '0 0 clamp(116px, 16vw, 10rem)',
         width: 'clamp(116px, 16vw, 10rem)',
+        aspectRatio: '1 / 1.4',
+    },
+    container: {
+        position: 'absolute',
+        inset: 0,
+        zIndex: 2,
+        isolation: 'isolate',
+        overflow: 'hidden',
         padding: '2px',
         borderRadius: '15px',
         border: '1px solid rgb(102, 229, 255)',
@@ -38,6 +50,20 @@ const styles = {
             },
         },
     },
+    // a card "edge" peeking out above the main card to suggest a stack; offset upward, behind, and
+    // scaled down (deeper == smaller). `top center` origin keeps the top edge peeking while it tapers.
+    stackLayer: (depth: number) => ({
+        position: 'absolute',
+        inset: 0,
+        zIndex: 1,
+        transformOrigin: 'top center',
+        transform: `translateY(-${depth * STACK_OFFSET_PX}px) scale(${STACK_SCALE ** depth})`,
+        borderRadius: '15px',
+        border: '1px solid rgba(102, 229, 255, 0.45)',
+        backgroundColor: '#16232B',
+        boxShadow: '0 -3px 7px rgba(0, 0, 0, 0.4)',
+        pointerEvents: 'none',
+    }),
     button: {
         position: 'relative',
         overflow: 'hidden',
@@ -98,6 +124,31 @@ const styles = {
         textTransform: 'uppercase',
         userSelect: 'none',
     },
+    // sits at the top-left of the frontmost card, straddling its top edge. Tweak `top`/`left` to taste.
+    countBadge: {
+        position: 'absolute',
+        // top: '0rem',
+        left: '50%',
+        transform: 'translateX(-50%) translateY(-50%)',
+        zIndex: 3,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minWidth: '30px',
+        height: '24px',
+        padding: '0 0.5rem',
+        color: 'white',
+        // opaque so the stacked card borders don't show through the label
+        backgroundColor: '#21414A',
+        border: '1px solid rgba(102, 229, 255, 0.85)',
+        borderRadius: '999px',
+        boxShadow: '0 2px 6px rgba(0, 0, 0, 0.55)',
+        fontSize: '0.8rem',
+        fontWeight: 700,
+        lineHeight: 1,
+        userSelect: 'none',
+        pointerEvents: 'none',
+    },
 }
 
 const cardArtBackground = (backgroundImage: string, isNoEffect: boolean) => ({
@@ -120,7 +171,7 @@ const cardArtBackground = (backgroundImage: string, isNoEffect: boolean) => ({
     },
 });
 
-const useCardImageURL = (sourceCard?: PopupSourceCard): string | null => {
+export const useCardImageURL = (sourceCard?: PopupSourceCard): string | null => {
     const locale = useCardImageLocale();
 
     if (!sourceCard || !sourceCard?.id || !sourceCard.type) {
@@ -134,41 +185,60 @@ const useCardImageURL = (sourceCard?: PopupSourceCard): string | null => {
     );
 }
 
-const isBaseSourceCard = (sourceCard?: PopupSourceCard): boolean => {
+export const isBaseSourceCard = (sourceCard?: PopupSourceCard): boolean => {
     const sourceType = sourceCard?.printedType ?? sourceCard?.type;
 
     return sourceType?.toLowerCase() === CardType.Base;
 };
 
-export default function TriggerButton({ onClick, sourceCard, text, hasLegalEffects }: { onClick(): void; sourceCard?: PopupSourceCard, text: string, hasLegalEffects?: boolean }) {
+export default function TriggerButton({ onClick, sourceCard, text, hasLegalEffects, count }: { onClick(): void; sourceCard?: PopupSourceCard, text: string, hasLegalEffects?: boolean, count?: number }) {
     const backgroundImage = useCardImageURL(sourceCard);
     const isLandscapePreview = isBaseSourceCard(sourceCard);
     const isNoEffect = !hasLegalEffects;
+    const isGrouped = (count ?? 0) > 1;
+    // show at most a 3-card stack regardless of how many triggers are grouped
+    const behindLayers = isGrouped ? Math.min(count ?? 1, 3) - 1 : 0;
 
     return (
-        <Box sx={[styles.container, isNoEffect && styles.noEffectContainer]}>
-            <Button
-                sx={[
-                    styles.button,
-                    backgroundImage 
-                        ? cardArtBackground(backgroundImage, isNoEffect)
-                        : { backgroundColor: '#1E2D32' }
-                ]}
-                onClick={onClick}
-            >
-                <RichText text={text} />
-            </Button>
-            {isNoEffect && (
+        <Box sx={styles.wrapper}>
+            {/* render deepest layer first so shallower layers stack on top of it */}
+            {Array.from({ length: behindLayers }).map((_, i) => {
+                const depth = behindLayers - i;
+                return <Box key={`stack-${depth}`} sx={styles.stackLayer(depth)} />;
+            })}
+            <Box sx={[styles.container, isNoEffect && styles.noEffectContainer]}>
+                <Button
+                    sx={[
+                        styles.button,
+                        backgroundImage
+                            ? cardArtBackground(backgroundImage, isNoEffect)
+                            : { backgroundColor: '#1E2D32' }
+                    ]}
+                    onClick={onClick}
+                >
+                    <RichText text={text} />
+                </Button>
+                {isNoEffect && (
+                    <Box
+                        component="span"
+                        aria-label="This choice has no effect"
+                        onClick={onClick}
+                        sx={styles.noEffectIndicator}
+                    >
+                        No effect
+                    </Box>
+                )}
+                {backgroundImage && <ViewCardButton imageUrl={backgroundImage} isLandscape={isLandscapePreview} />}
+            </Box>
+            {isGrouped && (
                 <Box
                     component="span"
-                    aria-label="This choice has no effect"
-                    onClick={onClick}
-                    sx={styles.noEffectIndicator}
+                    aria-label={`${count} similar triggers grouped together`}
+                    sx={styles.countBadge}
                 >
-                    No effect
+                    {`x${count}`}
                 </Box>
             )}
-            {backgroundImage && <ViewCardButton imageUrl={backgroundImage} isLandscape={isLandscapePreview} />}
         </Box>
     );
 }

--- a/src/app/_components/_sharedcomponents/Popup/PopupVariant/ActionTriggerPopup/index.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/PopupVariant/ActionTriggerPopup/index.tsx
@@ -33,6 +33,9 @@ const styles = {
         overflowY: 'hidden',
         paddingTop: '1.75rem',
         paddingBottom: '0.5rem',
+        // horizontal breathing room so the first/last cards' borders (and hover glow) aren't shaved by
+        // the scroll-clip edge when the row overflows
+        paddingInline: '1rem',
         marginTop: '0.25rem',
         marginBottom: '2rem',
     }

--- a/src/app/_components/_sharedcomponents/Popup/PopupVariant/ActionTriggerPopup/index.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/PopupVariant/ActionTriggerPopup/index.tsx
@@ -24,10 +24,16 @@ const styles = {
         width: '100%',
         flexDirection: 'row',
         justifyContent: 'safe center',
+        // cards are all the same size and bottom-aligned; grouped cards' stacked peek + count badge
+        // overflow upward into this reserved top padding so they are visible but don't shift the row.
+        // Keep paddingTop just above the max stack peek (2 layers x STACK_OFFSET_PX ~= 28px) to avoid
+        // dead space above the cards.
+        alignItems: 'flex-end',
         overflowX: 'auto',
         overflowY: 'hidden',
+        paddingTop: '1.75rem',
         paddingBottom: '0.5rem',
-        marginTop: '1rem',
+        marginTop: '0.25rem',
         marginBottom: '2rem',
     }
 };
@@ -65,6 +71,7 @@ export default function ActionTriggerPopupModal({ data }: ButtonProps) {
                                 text={button.text}
                                 sourceCard={button.sourceCard}
                                 hasLegalEffects={button.hasLegalEffects}
+                                count={button.count}
                                 onClick={() => {
                                     sendGameMessage([button.command, button.arg, button.uuid]);
                                 }}

--- a/src/app/_components/_sharedcomponents/Popup/PopupVariant/BatchTriggerPopup/index.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/PopupVariant/BatchTriggerPopup/index.tsx
@@ -1,0 +1,113 @@
+import { useGame } from '@/app/_contexts/Game.context';
+import { Box, IconButton, Typography } from '@mui/material';
+import { MouseEvent, useState } from 'react';
+import { BiMinus, BiPlus } from 'react-icons/bi';
+import {
+    containerStyle,
+    footerStyle,
+    headerStyle,
+    minimizeButtonStyle,
+    textStyle,
+    titleStyle,
+} from '../../Popup.styles';
+import { BatchTriggerPopup, PopupButton } from '../../Popup.types';
+import RichText from '../../../RichText/RichText';
+import GradientBorderButton from '@/app/_components/_sharedcomponents/_styledcomponents/GradientBorderButton';
+import ViewCardButton from '../ActionTriggerPopup/ViewCardButton';
+import { isBaseSourceCard, useCardImageURL } from '../ActionTriggerPopup/TriggerButton';
+
+interface IBatchTriggerPopupProps {
+    data: BatchTriggerPopup;
+}
+
+const styles = {
+    body: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: '0.75rem',
+        marginTop: '1rem',
+    },
+    cardContainer: {
+        position: 'relative',
+        isolation: 'isolate',
+        aspectRatio: '1 / 1.4',
+        width: 'clamp(140px, 22vw, 12rem)',
+        borderRadius: '15px',
+        // no cyan border here — this card is illustrative only (not selectable)
+        boxShadow: '0 2px 8px rgba(0, 0, 0, 0.45)',
+        backgroundColor: '#1E2D32',
+        backgroundPosition: 'center top',
+        backgroundSize: 'cover',
+        overflow: 'hidden',
+        '@media (hover: hover) and (pointer: fine)': {
+            '& .trigger-card-preview-button': {
+                opacity: 0,
+                pointerEvents: 'none',
+            },
+            '&:hover .trigger-card-preview-button': {
+                opacity: 1,
+                pointerEvents: 'auto',
+            },
+        },
+    },
+    remainingText: {
+        ...textStyle,
+        fontWeight: 600,
+    },
+};
+
+export default function BatchTriggerPopupModal({ data }: IBatchTriggerPopupProps) {
+    const { sendGameMessage } = useGame();
+    const [isMinimized, setIsMinimized] = useState(false);
+
+    const backgroundImage = useCardImageURL(data.sourceCard);
+    const isLandscapePreview = isBaseSourceCard(data.sourceCard);
+
+    const handleMinimize = (e: MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
+        setIsMinimized(!isMinimized);
+    };
+
+    return (
+        <Box sx={containerStyle}>
+            <Box sx={headerStyle(isMinimized)}>
+                <RichText text={data.title} sx={titleStyle} component={Typography}/>
+                <IconButton
+                    sx={minimizeButtonStyle}
+                    aria-label="minimize"
+                    onClick={handleMinimize}
+                >
+                    {isMinimized ? <BiPlus /> : <BiMinus />}
+                </IconButton>
+            </Box>
+            {!isMinimized && (
+                <Box sx={styles.body}>
+                    <Box
+                        sx={[
+                            styles.cardContainer,
+                            backgroundImage ? { backgroundImage: `url(${backgroundImage})` } : {},
+                        ]}
+                    >
+                        {backgroundImage && <ViewCardButton imageUrl={backgroundImage} isLandscape={isLandscapePreview} />}
+                    </Box>
+                    <Typography sx={styles.remainingText}>
+                        {`${data.remainingCount} trigger${data.remainingCount === 1 ? '' : 's'} remaining`}
+                    </Typography>
+                    <Box sx={footerStyle}>
+                        {data.buttons.map((button: PopupButton, index: number) => (
+                            <GradientBorderButton
+                                key={`${button.uuid}:${index}`}
+                                onClick={() => {
+                                    sendGameMessage([button.command, button.arg, button.uuid]);
+                                }}
+                            >
+                                <RichText text={button.text} />
+                            </GradientBorderButton>
+                        ))}
+                    </Box>
+                </Box>
+            )}
+        </Box>
+    );
+};

--- a/src/app/_contexts/Game.context.tsx
+++ b/src/app/_contexts/Game.context.tsx
@@ -147,6 +147,17 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
                     source: PopupSource.PromptState
                 });
             }
+            else if (promptType === 'batchTriggerResolution' && menuTitle && promptUuid && !selectCardMode) {
+                const batchData = promptState.batchTriggerResolution ?? {};
+                return openPopup('batchTrigger', {
+                    uuid: promptUuid,
+                    title: menuTitle,
+                    sourceCard: batchData.sourceCard,
+                    remainingCount: batchData.remainingCount,
+                    buttons,
+                    source: PopupSource.PromptState
+                });
+            }
             else if (buttons.length > 0 && menuTitle && promptUuid && !selectCardMode) {
                 const promptPopupType = promptType === 'triggerWindow' ? 'actionTrigger' : 'default';
                 return openPopup(promptPopupType, {

--- a/src/app/_contexts/Popup.context.tsx
+++ b/src/app/_contexts/Popup.context.tsx
@@ -2,6 +2,7 @@
 import React, { createContext, useContext, useCallback, useState } from 'react';
 import {
     ActionTriggerPopup,
+    BatchTriggerPopup,
     DefaultPopup,
     DropdownPopup,
     PilePopup,
@@ -11,6 +12,7 @@ import {
 
 export type PopupData =
   | ActionTriggerPopup
+  | BatchTriggerPopup
   | DefaultPopup
   | SelectCardsPopup
   | PilePopup


### PR DESCRIPTION
### ⚠️  Requires engine PR
https://github.com/SWU-Karabast/forceteki/pull/2634

## Description

Client support for the engine's grouped-trigger resolution flow.

### What
- Grouped triggers in the resolution-order prompt now render as a stacked-cards `TriggerButton` with an "xN" count badge.
- New `BatchTriggerPopup` modal (for the `batchTriggerResolution` prompt type): shows the trigger's source card + remaining count, with "Resolve next" / "Resolve all" actions.

### Technical callouts
- New `batchTrigger` popup variant, routed from `promptType === 'batchTriggerResolution'`.
- Adds `count` to `PopupButton`. Grouped items stay the exact size of single triggers so the row stays aligned; the stacked cards + badge overflow into reserved row headroom.

