### PR TITLE
Add sithvault to the list of supported deckbuilders

### DIFF
--- a/src/app/_utils/checkJson.ts
+++ b/src/app/_utils/checkJson.ts
@@ -227,6 +227,7 @@ export const parseInputAsDeckData = (input: string): {
         input.includes('holoscan.net') ||
         input.includes('niamos.net') ||
         input.includes('swupedia.com') ||
+        input.includes('sithvault.com') ||
         input.includes('melee.gg')
     ) {
         return { type: 'url', data: null };

--- a/src/app/_utils/deckProviders/SithvaultDeckProvider.ts
+++ b/src/app/_utils/deckProviders/SithvaultDeckProvider.ts
@@ -1,0 +1,37 @@
+import { DeckSource } from '../deckTypes';
+import { DeckProviderBase, IStatusErrorOverride } from './core/DeckProviderBase';
+import { DeckFetchErrorReason } from './core/types';
+
+export class SithvaultDeckProvider extends DeckProviderBase {
+    public override readonly source = DeckSource.SithVault;
+    public override readonly displayName = 'sithvault.com';
+    public override readonly hostNameMatch = 'sithvault.com';
+    public override readonly tagColor = '#E7000B';
+    public override readonly hiddenFromPublicList = false;
+    // Deck Links in the form: https://www.sithvault.com/decks/${deckId}
+    // Anchored on the uuid shape because SithVault also serves /decks/build,
+    // /decks/draft and /decks/trilogy/${id}; a looser capture matches those
+    // too and sends a meaningless id to the API.
+    protected override readonly deckIdRegex =
+        /sithvault\.com\/decks\/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(?=[/?#]|$)/;
+
+    // SithVault serves unlisted decks by link, so a 404 really does mean the
+    // deck is not saved to an account — there is no "make it public" step.
+    protected override readonly statusErrorOverrides: Partial<Record<number, IStatusErrorOverride>> = {
+        404: {
+            reason: DeckFetchErrorReason.NotFound,
+            message: 'Deck not found. Make sure the deck is saved to your account on sithvault.com.',
+        },
+        422: {
+            reason: DeckFetchErrorReason.ProviderError,
+            message: 'SithVault could not return a valid Karabast deck. Check that the deck has a leader and a base.',
+        },
+    };
+
+    // Hit the canonical `www.` host directly. The apex `sithvault.com`
+    // 307-redirects to `www.`, and browsers cannot follow cross-origin CORS
+    // redirects.
+    protected override buildApiUrl(deckId: string): string {
+        return `https://www.sithvault.com/decks/${deckId}/karabast`;
+    }
+}

--- a/src/app/_utils/deckProviders/core/registry.ts
+++ b/src/app/_utils/deckProviders/core/registry.ts
@@ -8,6 +8,7 @@ import { MeleeDeckProvider } from '../MeleeDeckProvider';
 import { MySwuDeckProvider } from '../MySwuDeckProvider';
 import { NiamosDeckProvider } from '../NiamosDeckProvider';
 import { ProtectThePodDeckProvider } from '../ProtectThePodDeckProvider';
+import { SithvaultDeckProvider } from '../SithvaultDeckProvider';
 import { SwubaseDeckProvider } from '../SwubaseDeckProvider';
 import { SwucardhubDeckProvider } from '../SwucardhubDeckProvider';
 import { SwudbDeckProvider } from '../SwudbDeckProvider';
@@ -47,6 +48,7 @@ const providers: readonly DeckProviderBase[] = [
     new CardcoreDeckProvider(),
     new HoloscanDeckProvider(),
     new SwupediaDeckProvider(),
+    new SithvaultDeckProvider(),
 ];
 
 /**

--- a/src/app/_utils/deckTypes.ts
+++ b/src/app/_utils/deckTypes.ts
@@ -32,7 +32,8 @@ export enum DeckSource {
     HoloScan = 'HoloScan',
     Melee = 'Melee',
     Niamos = 'Niamos',
-    SWUPedia = 'SWUPedia'
+    SWUPedia = 'SWUPedia',
+    SithVault = 'SithVault'
 }
 
 export interface IDeckData {


### PR DESCRIPTION
Includes sithvault.com in the list of supported deckbuilders.

SithVault serves the Karabast deck format at
`https://www.sithvault.com/decks/{deckId}/karabast`, with
`Access-Control-Allow-Origin` set for browser-side fetching.

Notes:
- Uses the `www.` host directly — the apex 307-redirects, and browsers can't
  follow cross-origin CORS redirects (same as ProtectThePod).
- `deckIdRegex` is anchored on the deck uuid because SithVault also serves
  `/decks/build`, `/decks/draft` and `/decks/trilogy/{id}`.
- Unlisted decks resolve by link, so the 404 override says "saved to your
  account" rather than "make it public".

Proof:
<img width="945" height="648" alt="deck_saved" src="https://github.com/user-attachments/assets/7a998894-3c9b-41e2-bf55-1372e41d7d43" />
<img width="758" height="645" alt="dropdown" src="https://github.com/user-attachments/assets/851e8c15-6665-4dca-88d4-8a9c4790731f" />
