### PR TITLE
Disable autoscroll

### DIFF
--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -526,6 +526,7 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
                 chatMessage={chatMessage}
                 handleChatOnChange={handleChatOnChange}
                 handleChatSubmit={handleGameChat}
+                pauseAutoScroll
             />
 
             <LobbyConfirmationPopupModule title={'Concede Game Confirmation'} message={'Are you sure you wish to concede? This game will count as a loss.'} display={showConcedeConfirmation} onConfirmation={handleConfirmConcede} handleCancel={handleCancelConcede}/>

--- a/src/app/_components/_sharedcomponents/Chat/Chat.tsx
+++ b/src/app/_components/_sharedcomponents/Chat/Chat.tsx
@@ -1,6 +1,8 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
     Box,
+    Button,
+    Divider,
     TextField,
     IconButton,
     InputAdornment,
@@ -30,10 +32,14 @@ const Chat: React.FC<IChatProps> = ({
     chatMessage,
     handleChatOnChange,
     handleChatSubmit,
+    pauseAutoScroll = false,
 }) => {
     const { lobbyState, connectedPlayer, isSpectator, getOpponent, isAnonymousPlayer, hasChatDisabled } = useGame();
-    const chatEndRef = useRef<HTMLDivElement | null>(null);
+    const chatBoxRef = useRef<HTMLDivElement | null>(null);
+    const lastScrollTopRef = useRef(0);
     const previousMessagesRef = useRef<IChatEntry[]>([]);
+    const [isScrollPaused, setIsScrollPaused] = useState(false);
+    const [unreadStartIndex, setUnreadStartIndex] = useState<number | null>(null);
     const { user } = useUser();
 
     // Initialize sound handler with user preferences
@@ -293,20 +299,111 @@ const Chat: React.FC<IChatProps> = ({
         previousMessagesRef.current = [...chatHistory];
     }, [chatHistory, connectedPlayer, isSpectator]);
 
-    useEffect(() => {
-        if(chatEndRef.current) {
-            chatEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    const scrollToLatest = (behavior: ScrollBehavior = 'smooth') => {
+        const chatBox = chatBoxRef.current;
+        if (!chatBox) return;
+
+        lastScrollTopRef.current = chatBox.scrollTop;
+        chatBox.scrollTo({ top: chatBox.scrollHeight, behavior });
+    };
+
+    const handleChatScroll = (event: React.UIEvent<HTMLDivElement>) => {
+        const chatBox = event.currentTarget;
+        const isScrollingUp = chatBox.scrollTop < lastScrollTopRef.current;
+        const isAwayFromBottom = chatBox.scrollHeight - chatBox.scrollTop - chatBox.clientHeight > 24;
+
+        lastScrollTopRef.current = chatBox.scrollTop;
+
+        if (isScrollPaused && !isAwayFromBottom) {
+            setIsScrollPaused(false);
+            setUnreadStartIndex(null);
+            return;
         }
-    }, [chatHistory]);
+
+        if (pauseAutoScroll && !isScrollPaused && isScrollingUp && isAwayFromBottom) {
+            setIsScrollPaused(true);
+            setUnreadStartIndex(chatHistory.length);
+        }
+    };
+
+    const resumeChat = () => {
+        setIsScrollPaused(false);
+        setUnreadStartIndex(null);
+    };
+
+    const unreadMessageCount = unreadStartIndex === null
+        ? 0
+        : Math.max(0, chatHistory.length - unreadStartIndex);
+
+    useEffect(() => {
+        if (!isScrollPaused) {
+            scrollToLatest();
+        }
+    }, [chatHistory, isScrollPaused]);
+
+    useEffect(() => {
+        if (unreadStartIndex !== null && chatHistory.length < unreadStartIndex) {
+            setIsScrollPaused(false);
+            setUnreadStartIndex(null);
+        }
+    }, [chatHistory.length, unreadStartIndex]);
     // ------------------------STYLES------------------------//
 
     const styles = {
+        chatScrollContainer: {
+            position: 'relative',
+            display: 'flex',
+            flex: 1,
+            minHeight: 0,
+        },
         chatBox: {
             p: '0.5em',
             minHeight: '100px',
             overflowY: 'auto',
             backgroundColor: '#28282800',
             flex: 1,
+        },
+        pausedButton: {
+            position: 'absolute',
+            zIndex: 2,
+            bottom: '0.5rem',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: 'calc(100% - 1rem)',
+            maxWidth: '15rem',
+            minWidth: 0,
+            px: '0.8rem',
+            py: '0.35rem',
+            borderRadius: '999px',
+            color: '#fff',
+            backgroundColor: 'rgba(20, 20, 20, 0.94)',
+            border: '1px solid rgba(255, 254, 80, 0.55)',
+            fontSize: '0.75rem',
+            lineHeight: 1.2,
+            textTransform: 'none',
+            whiteSpace: 'nowrap',
+            boxShadow: '0 2px 8px rgba(0, 0, 0, 0.4)',
+            '&:hover': {
+                backgroundColor: 'rgba(40, 40, 40, 0.98)',
+                '& .paused-label': {
+                    display: 'none',
+                },
+                '& .unread-label': {
+                    display: 'inline',
+                },
+            },
+        },
+        unreadLabel: {
+            display: 'none',
+        },
+        newMessagesDivider: {
+            my: '0.25rem',
+            color: '#FFFE50',
+            fontSize: '0.7rem',
+            '&::before, &::after': {
+                borderColor: '#FFFE50',
+                opacity: 0.7,
+            },
         },
         chatMessageStack: {
             minHeight: '100%',
@@ -414,12 +511,30 @@ const Chat: React.FC<IChatProps> = ({
 
     return (
         <>
-            <Box sx={styles.chatBox}>
-                <Box sx={styles.chatMessageStack}>
-                    {chatHistory && chatHistory.map((chatEntry: IChatEntry, index: number) => {
-                        return formatMessage(chatEntry?.message, index);
-                    })}
-                    <Box ref={chatEndRef} />
+            <Box sx={styles.chatScrollContainer}>
+                {isScrollPaused && (
+                    <Button
+                        onClick={resumeChat}
+                        sx={styles.pausedButton}
+                        aria-label={`Chat paused due to scrolling. ${unreadMessageCount} new messages. Click to resume.`}
+                    >
+                        <span className="paused-label">Chat paused due to scrolling</span>
+                        <Box component="span" className="unread-label" sx={styles.unreadLabel}>
+                            {unreadMessageCount} new {unreadMessageCount === 1 ? 'message' : 'messages'}
+                        </Box>
+                    </Button>
+                )}
+                <Box ref={chatBoxRef} onScroll={handleChatScroll} sx={styles.chatBox}>
+                    <Box sx={styles.chatMessageStack}>
+                        {chatHistory && chatHistory.map((chatEntry: IChatEntry, index: number) => (
+                            <React.Fragment key={`${chatEntry.date}-${index}`}>
+                                {unreadStartIndex === index && unreadMessageCount > 0 && (
+                                    <Divider sx={styles.newMessagesDivider}>New messages</Divider>
+                                )}
+                                {formatMessage(chatEntry?.message, index)}
+                            </React.Fragment>
+                        ))}
+                    </Box>
                 </Box>
             </Box>
 

--- a/src/app/_components/_sharedcomponents/Chat/ChatTypes.ts
+++ b/src/app/_components/_sharedcomponents/Chat/ChatTypes.ts
@@ -49,4 +49,5 @@ export interface IChatProps {
     chatMessage: string;
     handleChatOnChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
     handleChatSubmit: () => void;
+    pauseAutoScroll?: boolean;
 }


### PR DESCRIPTION
## Summary

 - Pause automatic chat scrolling when the user scrolls up.
 - Display a floating paused-chat indicator at the bottom of the chat history.
 - Show the number of unread messages when hovering over the indicator.
 - Add a divider between previously viewed and unread messages.
 - Resume automatic scrolling when the indicator is clicked or the user scrolls to the latest message.
 - Keep the existing lobby chat behavior unchanged.

## Why

Chat updates previously forced the drawer to scroll to the latest message, making it difficult to review earlier messages during an active game.

## UI


https://drive.google.com/file/d/1E9H-hZbT1zA5HQ0_g2jlBQiZ_N-yRmgJ/view?usp=sharing