### PR TITLE
Redesign the optional trigger prompt to match card-as-button language

### DIFF
--- a/src/app/_components/_sharedcomponents/Popup/Popup.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/Popup.tsx
@@ -2,10 +2,11 @@
 import { PopupData, PopupType, usePopup } from '@/app/_contexts/Popup.context';
 import { Box, SxProps, Theme } from '@mui/material';
 import React from 'react';
-import { ActionTriggerPopup, BatchTriggerPopup, DefaultPopup, DropdownPopup, NumberPopup, PilePopup, SelectCardsPopup, WaitDelayPopup } from './Popup.types';
+import { ActionTriggerPopup, BatchTriggerPopup, DefaultPopup, DropdownPopup, NumberPopup, OptionalTriggerPopup, PilePopup, SelectCardsPopup, WaitDelayPopup } from './Popup.types';
 import { DefaultPopupModal } from './PopupVariant/DefaultPopup';
 import ActionTriggerPopupModal from './PopupVariant/ActionTriggerPopup';
 import BatchTriggerPopupModal from './PopupVariant/BatchTriggerPopup';
+import OptionalTriggerPopupModal from './PopupVariant/OptionalTriggerPopup';
 import { PilePopupModal } from './PopupVariant/PilePopup';
 import { SelectCardsPopupModal } from './PopupVariant/SelectCardsPopup';
 import { contentStyle } from './Popup.styles';
@@ -78,6 +79,8 @@ const PopupShell: React.FC<IPopupShellProps> = ({
                 return <ActionTriggerPopupModal data={data as ActionTriggerPopup} />;
             case 'batchTrigger':
                 return <BatchTriggerPopupModal data={data as BatchTriggerPopup} />;
+            case 'optionalTrigger':
+                return <OptionalTriggerPopupModal data={data as OptionalTriggerPopup} />;
             case 'default':
                 return <DefaultPopupModal data={data as DefaultPopup} />;
             case 'pile':
@@ -109,7 +112,7 @@ const PopupShell: React.FC<IPopupShellProps> = ({
         )
     }
 
-    const centeredModalTypes: PopupType[] = ['default', 'actionTrigger', 'batchTrigger'];
+    const centeredModalTypes: PopupType[] = ['default', 'actionTrigger', 'batchTrigger', 'optionalTrigger'];
     const [nonDefaultPopups, defaultPopups] = [
         popups.filter((popup) => !centeredModalTypes.includes(popup.type)),
         popups.filter((popup) => centeredModalTypes.includes(popup.type))

--- a/src/app/_components/_sharedcomponents/Popup/Popup.types.ts
+++ b/src/app/_components/_sharedcomponents/Popup/Popup.types.ts
@@ -23,6 +23,8 @@ export type PopupButton = {
     hasLegalEffects?: boolean;
     selected?: boolean;
     disabled?: boolean;
+    // display label rendered in place of `text` by richer prompt UIs (e.g. the ability name on an optional-trigger card button)
+    label?: string;
     // number of similar triggers this button represents when several are grouped into one choice
     count?: number;
 };
@@ -65,8 +67,6 @@ export type OptionalTriggerPopup = {
     type: 'optionalTrigger';
     uuid: string;
     title: string;
-    sourceCard?: PopupSourceCard;
-    abilityText?: string;
     buttons: PopupButton[];
     source: PopupSource;
 };

--- a/src/app/_components/_sharedcomponents/Popup/Popup.types.ts
+++ b/src/app/_components/_sharedcomponents/Popup/Popup.types.ts
@@ -61,6 +61,16 @@ export type BatchTriggerPopup = {
     source: PopupSource;
 };
 
+export type OptionalTriggerPopup = {
+    type: 'optionalTrigger';
+    uuid: string;
+    title: string;
+    sourceCard?: PopupSourceCard;
+    abilityText?: string;
+    buttons: PopupButton[];
+    source: PopupSource;
+};
+
 export type SelectCardsPopup = {
     type: 'select';
     uuid: string;

--- a/src/app/_components/_sharedcomponents/Popup/PopupVariant/ActionTriggerPopup/TriggerButton.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/PopupVariant/ActionTriggerPopup/TriggerButton.tsx
@@ -13,6 +13,9 @@ type SourceCardImageData = Parameters<typeof s3CardImageURL>[0];
 export const STACK_OFFSET_PX = 10;
 export const STACK_SCALE = 0.92; // scale factor for each stacked card; smaller = more obvious stack
 
+// the card's width, exported so sibling controls (e.g. a Pass button beneath) can match it exactly
+export const CARD_WIDTH = 'clamp(116px, 16vw, 10rem)';
+
 const styles = {
     // the flex item. It is always exactly one card in size (same as an ungrouped trigger) so the row
     // stays aligned; the stacked cards and count badge overflow upward beyond it without affecting layout.
@@ -20,8 +23,8 @@ const styles = {
         position: 'relative',
         // to avoid cutoff when doing the Y translation on hover effect
         mt: '1px',
-        flex: '0 0 clamp(116px, 16vw, 10rem)',
-        width: 'clamp(116px, 16vw, 10rem)',
+        flex: `0 0 ${CARD_WIDTH}`,
+        width: CARD_WIDTH,
         aspectRatio: '1 / 1.4',
     },
     container: {

--- a/src/app/_components/_sharedcomponents/Popup/PopupVariant/OptionalTriggerPopup/index.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/PopupVariant/OptionalTriggerPopup/index.tsx
@@ -49,7 +49,7 @@ export default function OptionalTriggerPopupModal({ data }: ButtonProps) {
     return (
         <Box sx={containerStyle}>
             <Box sx={headerStyle(isMinimized)}>
-                <RichText text="You may trigger this ability" sx={titleStyle} component={Typography} />
+                <RichText text={data.title} sx={titleStyle} component={Typography} />
                 <IconButton
                     sx={minimizeButtonStyle}
                     aria-label="minimize"
@@ -62,8 +62,8 @@ export default function OptionalTriggerPopupModal({ data }: ButtonProps) {
                 <>
                     <Box sx={styles.modalContent}>
                         <TriggerButton
-                            text={data.abilityText ?? triggerButton.text}
-                            sourceCard={data.sourceCard}
+                            text={triggerButton.label ?? triggerButton.text}
+                            sourceCard={triggerButton.sourceCard}
                             hasLegalEffects
                             onClick={() => sendGameMessage([triggerButton.command, triggerButton.arg, triggerButton.uuid])}
                         />

--- a/src/app/_components/_sharedcomponents/Popup/PopupVariant/OptionalTriggerPopup/index.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/PopupVariant/OptionalTriggerPopup/index.tsx
@@ -1,0 +1,85 @@
+import { useGame } from '@/app/_contexts/Game.context';
+import { Box, IconButton, Typography } from '@mui/material';
+import { MouseEvent, useState } from 'react';
+import { BiMinus, BiPlus } from 'react-icons/bi';
+import GradientBorderButton from '@/app/_components/_sharedcomponents/_styledcomponents/GradientBorderButton';
+import {
+    containerStyle,
+    headerStyle,
+    minimizeButtonStyle,
+    titleStyle,
+} from '../../Popup.styles';
+import { OptionalTriggerPopup } from '../../Popup.types';
+import RichText from '../../../RichText/RichText';
+import TriggerButton, { CARD_WIDTH } from '../ActionTriggerPopup/TriggerButton';
+
+interface ButtonProps {
+    data: OptionalTriggerPopup;
+}
+
+const styles = {
+    modalContent: {
+        display: 'flex',
+        justifyContent: 'center',
+        marginTop: '0.5rem',
+    },
+    // paired tightly with the card above and matched to its width, so the two read as one control
+    passButtonRow: {
+        display: 'flex',
+        justifyContent: 'center',
+        marginTop: '0.5rem',
+    },
+    passButton: {
+        width: CARD_WIDTH,
+    },
+};
+
+export default function OptionalTriggerPopupModal({ data }: ButtonProps) {
+    const { sendGameMessage } = useGame();
+    const [isMinimized, setIsMinimized] = useState(false);
+
+    const handleMinimize = (e: MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
+        setIsMinimized(!isMinimized);
+    };
+
+    const triggerButton = data.buttons.find((button) => button.text.toLowerCase() === 'trigger') ?? data.buttons[0];
+    const passButton = data.buttons.find((button) => button !== triggerButton);
+
+    return (
+        <Box sx={containerStyle}>
+            <Box sx={headerStyle(isMinimized)}>
+                <RichText text="You may trigger this ability" sx={titleStyle} component={Typography} />
+                <IconButton
+                    sx={minimizeButtonStyle}
+                    aria-label="minimize"
+                    onClick={handleMinimize}
+                >
+                    {isMinimized ? <BiPlus /> : <BiMinus />}
+                </IconButton>
+            </Box>
+            {!isMinimized && (
+                <>
+                    <Box sx={styles.modalContent}>
+                        <TriggerButton
+                            text={data.abilityText ?? triggerButton.text}
+                            sourceCard={data.sourceCard}
+                            hasLegalEffects
+                            onClick={() => sendGameMessage([triggerButton.command, triggerButton.arg, triggerButton.uuid])}
+                        />
+                    </Box>
+                    {passButton && (
+                        <Box sx={styles.passButtonRow}>
+                            <GradientBorderButton
+                                sx={styles.passButton}
+                                onClick={() => sendGameMessage([passButton.command, passButton.arg, passButton.uuid])}
+                            >
+                                <RichText text={passButton.text} />
+                            </GradientBorderButton>
+                        </Box>
+                    )}
+                </>
+            )}
+        </Box>
+    );
+}

--- a/src/app/_contexts/Game.context.tsx
+++ b/src/app/_contexts/Game.context.tsx
@@ -166,13 +166,10 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
                     source: PopupSource.PromptState
                 });
             }
-            else if (promptType === 'optionalTrigger' && promptState.optionalTrigger?.sourceCard && menuTitle && promptUuid && !selectCardMode) {
-                const optionalTriggerData = promptState.optionalTrigger;
+            else if (promptType === 'optionalTrigger' && menuTitle && promptUuid && !selectCardMode) {
                 return openPopup('optionalTrigger', {
                     uuid: promptUuid,
                     title: menuTitle,
-                    sourceCard: optionalTriggerData.sourceCard,
-                    abilityText: optionalTriggerData.abilityText,
                     buttons,
                     source: PopupSource.PromptState
                 });

--- a/src/app/_contexts/Game.context.tsx
+++ b/src/app/_contexts/Game.context.tsx
@@ -166,6 +166,17 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
                     source: PopupSource.PromptState
                 });
             }
+            else if (promptType === 'optionalTrigger' && promptState.optionalTrigger?.sourceCard && menuTitle && promptUuid && !selectCardMode) {
+                const optionalTriggerData = promptState.optionalTrigger;
+                return openPopup('optionalTrigger', {
+                    uuid: promptUuid,
+                    title: menuTitle,
+                    sourceCard: optionalTriggerData.sourceCard,
+                    abilityText: optionalTriggerData.abilityText,
+                    buttons,
+                    source: PopupSource.PromptState
+                });
+            }
             else if (buttons.length > 0 && menuTitle && promptUuid && !selectCardMode) {
                 const promptPopupType = promptType === 'triggerWindow' ? 'actionTrigger' : 'default';
                 return openPopup(promptPopupType, {

--- a/src/app/_contexts/Popup.context.tsx
+++ b/src/app/_contexts/Popup.context.tsx
@@ -5,6 +5,7 @@ import {
     BatchTriggerPopup,
     DefaultPopup,
     DropdownPopup,
+    OptionalTriggerPopup,
     PilePopup,
     SelectCardsPopup,
     PopupSource, LeaveGamePopup, NumberPopup, WaitDelayPopup
@@ -13,6 +14,7 @@ import {
 export type PopupData =
   | ActionTriggerPopup
   | BatchTriggerPopup
+  | OptionalTriggerPopup
   | DefaultPopup
   | SelectCardsPopup
   | PilePopup


### PR DESCRIPTION
:warning: Engine PR: SWU-Karabast/forceteki#2641

## Summary
Redesigns the optional triggered-ability prompt to match the card-as-button language: the ability's source card is shown as the Trigger button (with the ability text as its label), above a Pass button.

## Changes
- Add an `OptionalTriggerPopup` variant and route the `optionalTrigger` prompt type to it.
- Read the source card and ability label off the Trigger button; the header is server-driven from prompt state.
- Add an optional `label` field to `PopupButton`.

## Screenshots

| Before | After |
| :---: | :---: |
| <img width="400" src="https://github.com/user-attachments/assets/66ee9381-7f7c-43ed-aeaf-c51cd6d11757" /> | <img width="400" src="https://github.com/user-attachments/assets/31c0a320-cb86-45e0-92f2-f3ff55f64d57" /> |
