### PR TITLE
Fix mobile drawer confirmation modals

### DIFF
--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -529,9 +529,6 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
                 pauseAutoScroll
             />
 
-            <LobbyConfirmationPopupModule title={'Concede Game Confirmation'} message={'Are you sure you wish to concede? This game will count as a loss.'} display={showConcedeConfirmation} onConfirmation={handleConfirmConcede} handleCancel={handleCancelConcede}/>
-            <LobbyConfirmationPopupModule title={'Disable Chat Confirmation'} message={'Are you sure you wish to disable chat for this game? This action is not reversable.'} display={showDisableChatConfirmation} onConfirmation={handleConfirmDisableChat} handleCancel={handleCancelDisableChat}/>
-            <PlayerReportDialog open={playerReportOpen} onClose={handleClosePlayerReport}/>
         </>
     );
 
@@ -547,6 +544,9 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
             >
                 {drawerContent}
             </Drawer>
+            <LobbyConfirmationPopupModule title={'Concede Game Confirmation'} message={'Are you sure you wish to concede? This game will count as a loss.'} display={showConcedeConfirmation} onConfirmation={handleConfirmConcede} handleCancel={handleCancelConcede}/>
+            <LobbyConfirmationPopupModule title={'Disable Chat Confirmation'} message={'Are you sure you wish to disable chat for this game? This action is not reversable.'} display={showDisableChatConfirmation} onConfirmation={handleConfirmDisableChat} handleCancel={handleCancelDisableChat}/>
+            <PlayerReportDialog open={playerReportOpen} onClose={handleClosePlayerReport}/>
         </>
     );
 };


### PR DESCRIPTION
## Summary

When opening "exit modals" inside the mobile chat drawer, it causes them to desappear after the drawer unmounts.

## Changes

 - Render game-action dialogs outside the temporary mobile drawer
 - Prevent the concede confirmation from disappearing when the drawer closes
 - Apply the same lifecycle fix to the disable-chat and player-report dialogs

## Bug


https://github.com/user-attachments/assets/90084b54-ac59-45b8-a8aa-4c1b78032323


## Fix

https://github.com/user-attachments/assets/bca0b300-c223-4838-bf62-346db0b51ac0


