### PR TITLE
Landscape mobile drawer now behaves like desktop

### DIFF
--- a/src/app/GameBoard/page.tsx
+++ b/src/app/GameBoard/page.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 'use client';
 import React, { useState, useEffect } from 'react';
-import { Box, Grid } from '@mui/material';
+import { Box, Grid, useMediaQuery } from '@mui/material';
 import ChatDrawer from '../_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer';
 import OpponentCardTray from '../_components/Gameboard/OpponentCardTray/OpponentCardTray';
 import Board from '../_components/Gameboard/Board/Board';
@@ -19,6 +19,7 @@ const GameBoard = () => {
     const router = useRouter();
     const sidebarState = localStorage.getItem('sidebarState') !== null ? localStorage.getItem('sidebarState') === 'true' : true;
     const [sidebarOpen, setSidebarOpen] = useState(sidebarState);
+    const isMobileLandscape = useMediaQuery('(orientation: landscape) and (max-width: 932px)');
     const [isPreferenceOpen, setPreferenceOpen] = useState(false);
     const [userClosedWinScreen, setUserClosedWinScreen] = useState(false);
     const user = gameState?.players[connectedPlayer]?.user;
@@ -29,6 +30,12 @@ const GameBoard = () => {
     // const opponentUser = gameState?.players[getOpponent(connectedPlayer)].user;
     // const theirPlaymatId = !playMatsDisabled ? opponentUser?.cosmetics?.playmat : null;
     // const theirPlaymat = !playMatsDisabled && theirPlaymatId && theirPlaymatId ? getPlaymat(theirPlaymatId) : null;
+
+    useEffect(() => {
+        if (isMobileLandscape) {
+            setSidebarOpen(true);
+        }
+    }, [isMobileLandscape]);
 
     useEffect(() => {
         if(lobbyState && !lobbyState.gameOngoing && (lobbyState.gameType !== MatchmakingType.Quick || lobbyState.winHistory.gamesToWinMode === GamesToWinMode.BestOfThree)) {
@@ -100,6 +107,9 @@ const GameBoard = () => {
     const styles = {
         mainBoxStyle: {
             pr: sidebarOpen ? { xs: 0, md: 'min(20%, 280px)' } : '0',
+            '@media (orientation: landscape) and (max-width: 932px)': {
+                paddingRight: sidebarOpen ? 'min(20%, 280px)' : 0,
+            },
             width: '100%',
             transition: 'padding-right 0.3s ease-in-out',
             height: '100dvh',
@@ -119,6 +129,9 @@ const GameBoard = () => {
             bottom: 0, // Touch bottom edge
             left: '2rem', // Add left margin to constrain width
             right: sidebarOpen ? { xs: '2rem', md: 'calc(min(20%, 280px) + 2rem)' } : '2rem', // Add right margin to match
+            '@media (orientation: landscape) and (max-width: 932px)': {
+                right: sidebarOpen ? 'calc(min(20%, 280px) + 2rem)' : '2rem',
+            },
             height: '47dvh', // Reduced height for middle spacing
             backgroundSize: 'cover', // Fill container width, crop overflow edges
             backgroundPosition: 'center center',
@@ -133,6 +146,9 @@ const GameBoard = () => {
             top: 0, // Touch top edge
             left: '2rem', // Add left margin to constrain width
             right: sidebarOpen ? { xs: '2rem', md: 'calc(min(20%, 280px) + 2rem)' } : '2rem', // Add right margin to match
+            '@media (orientation: landscape) and (max-width: 932px)': {
+                right: sidebarOpen ? 'calc(min(20%, 280px) + 2rem)' : '2rem',
+            },
             height: '47dvh', // Reduced height for middle spacing
             backgroundSize: 'cover', // Fill container width, crop overflow edges
             backgroundPosition: 'center center',

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -56,6 +56,11 @@ const styles = {
             padding: '0.75em',
             overflow: { xs: 'visible', md: 'hidden' },
             borderLeft: drawerBorder,
+            '@media (orientation: landscape) and (max-width: 932px)': {
+                backgroundColor: '#000000CC',
+                width: 'min(20%, 280px)',
+                overflow: 'hidden',
+            },
         },
     },
     drawerToggle: {
@@ -100,6 +105,9 @@ const styles = {
     drawerToggleClosed: { right: 0, '&::after': { transform: 'rotate(45deg)' } },
     drawerToggleOpen: {
         right: { xs: '200px', md: 'min(20%, 280px)' },
+        '@media (orientation: landscape) and (max-width: 932px)': {
+            right: 'min(20%, 280px)',
+        },
         '&::before': {
             right: '-1px',
             backgroundColor: { md: '#000000CC' },
@@ -278,6 +286,8 @@ const UndoButton = ({ disabledOverride = false }: { disabledOverride?: boolean }
 const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, preferenceToggle }) => {
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+    const isMobileLandscape = useMediaQuery('(orientation: landscape) and (max-width: 932px)');
+    const usesTemporaryDrawer = isMobile && !isMobileLandscape;
     const {
         gameState,
         gameMessages,
@@ -391,7 +401,7 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
     }
 
     const closeMobileDrawer = () => {
-        if (isMobile) {
+        if (usesTemporaryDrawer) {
             handleDrawerClose();
         }
     }
@@ -542,7 +552,7 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
                 anchor="right"
                 open={sidebarOpen}
                 onClose={handleDrawerClose}
-                variant={isMobile ? 'temporary' : 'persistent'}
+                variant={usesTemporaryDrawer ? 'temporary' : 'persistent'}
                 sx={styles.drawerStyle}
             >
                 {drawerContent}

--- a/src/app/_components/_sharedcomponents/Popup/Popup.tsx
+++ b/src/app/_components/_sharedcomponents/Popup/Popup.tsx
@@ -31,7 +31,13 @@ export const getPopupPosition = (type: PopupType, data: PopupData, index: number
         top: '50%',
         transform: 'translate(-50%, -50%)',
         minWidth: '80%',
-        width: { xs: 'calc(100dvw - 2rem)', md: '80%' }
+        width: { xs: 'calc(100dvw - 2rem)', md: '80%' },
+        '@media (orientation: landscape) and (max-width: 932px)': {
+            // The persistent chat drawer occupies part of PopupShell in mobile
+            // landscape, so size the popup from that remaining space instead
+            // of the full viewport.
+            width: 'calc(100% - 2rem)',
+        },
     };
 
     // const pilePosition = {

--- a/src/app/_components/_sharedcomponents/Preferences/PreferencesComponent.tsx
+++ b/src/app/_components/_sharedcomponents/Preferences/PreferencesComponent.tsx
@@ -23,6 +23,9 @@ const PreferencesComponent: React.FC<IPreferenceProps> = ({
             display: isPreferenceOpen ? 'block' : 'none',
             position: variant === 'homePage' ? { xs: 'relative', md: 'absolute' } : 'absolute',
             width: sidebarOpen ? { xs: '100%', md: 'calc(100% - min(20%, 280px))' } : '100%',
+            '@media (orientation: landscape) and (max-width: 932px)': {
+                width: sidebarOpen ? 'calc(100% - min(20%, 280px))' : '100%',
+            },
             height: variant === 'homePage' ? { xs: 'auto', md: '100%' } : '100%',
             backgroundColor: variant ==='gameBoard' ? 'rgba(0, 0, 0, 0.5)' : 'none',
             zIndex: variant === 'homePage' ? 1 : 999,


### PR DESCRIPTION
## Changes

Landscape mobile drawer now behaver like desktop: it ocuppies space and players can have it opened at all times.


## Current behavior

https://github.com/user-attachments/assets/198be9f4-5a98-4c2b-993c-66ea6c6322b6




## New behavior



https://github.com/user-attachments/assets/d3133bc9-a068-45fe-9e35-5c8aa08c1551



