### PR TITLE
Timer resizing to give lastPlayedCard space to grow

### DIFF
--- a/src/app/_components/Gameboard/OpponentCardTray/OpponentCardTray.tsx
+++ b/src/app/_components/Gameboard/OpponentCardTray/OpponentCardTray.tsx
@@ -56,12 +56,21 @@ const OpponentCardTray: React.FC<IOpponentCardTrayProps> = ({ trayPlayer }) => {
     const styles = {
         leftColumn: {
             ...debugBorder('red'),
-            flexDirection: isPortrait ? 'column' : 'row', // Responsive layout
+            flexDirection: 'row', // Responsive layout
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'flex-start',
-            padding: isPortrait ? '0.5rem' : '1.0rem',
+            padding: '1rem',
             gap: '1rem',
+            // Mobile landscape
+            '@media (orientation: landscape) and (max-width: 932px)': {
+                py: '8px',
+            },
+            // Mobile portrait
+            '@media (orientation: portrait) and (max-width: 932px)': {
+                p: '0.5rem',
+                flexDirection: 'column',
+            },
             height: '100%',
             boxSizing: 'border-box',
         },
@@ -92,8 +101,19 @@ const OpponentCardTray: React.FC<IOpponentCardTrayProps> = ({ trayPlayer }) => {
             alignItems: 'center',
             justifyContent: 'flex-end',
             py: '1rem',
-            pr: { xs: '1rem', md: '2rem' },
-            gap: { xs: hasLastPlayedCard ? '1rem' : '0', md: '1rem' },
+            pr: '2rem',
+            gap: '1rem',
+            // Mobile portrait
+            '@media (orientation: portrait) and (max-width: 932px)': {
+                pr: '5px',
+                gap: hasLastPlayedCard ? '6px' : '0',
+            },
+            // Mobile landscape
+            '@media (orientation: landscape) and (max-width: 932px)': {
+                pr: '1rem',
+                gap: hasLastPlayedCard ? '1rem' : '0',
+                py: '8px',
+            },
         },
         lastPlayed: {
             ...debugBorder('yellow'),
@@ -153,6 +173,10 @@ const OpponentCardTray: React.FC<IOpponentCardTrayProps> = ({ trayPlayer }) => {
                 display: 'flex',
                 flexWrap: 'nowrap',
                 columnGap: '1rem', // 2rem gap between columns
+                // Mobile portrait
+                '@media (orientation: portrait) and (max-width: 932px)': {
+                    columnGap: '6px',
+                },
                 position: 'relative',
                 zIndex: 2 // Above playmats
             }}

--- a/src/app/_components/Gameboard/PlayerCardTray/PlayerCardTray.tsx
+++ b/src/app/_components/Gameboard/PlayerCardTray/PlayerCardTray.tsx
@@ -86,6 +86,9 @@ const PlayerCardTray: React.FC<IPlayerCardTrayProps> = ({ trayPlayer }) => {
                 display: 'flex',
                 flexWrap: 'nowrap',
                 columnGap: '1rem',
+                '@media (orientation: portrait) and (max-width: 932px)': {
+                    columnGap: '6px',
+                },
                 position: 'relative',
                 zIndex: 2 // Above playmats
             }}

--- a/src/app/_components/_sharedcomponents/Timer/MainTimerLabel.tsx
+++ b/src/app/_components/_sharedcomponents/Timer/MainTimerLabel.tsx
@@ -6,7 +6,7 @@ const labelDefaultStyles = {
     marginBottom: 0,
     cursor: 'pointer',
     fontWeight: 600,
-    fontSize: { xs: '1.5rem', md: '1rem' }
+    fontSize: { xs: '0.8rem', md: '1rem' }
 };
 
 const Divider = () => <div style={{ height: '1px', width: '100%', background: 'white', opacity: 0.3, marginTop: '2px' }} />;

--- a/src/app/_components/_sharedcomponents/Timer/Timer.tsx
+++ b/src/app/_components/_sharedcomponents/Timer/Timer.tsx
@@ -6,6 +6,7 @@ import React, { useMemo } from 'react';
 import Tooltip, { TooltipProps } from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { formatMilliseconds, getTimerColor } from './timerUtils';
+import { useMediaQuery, useTheme } from '@mui/material';
 
 const TIMER_STEP = 100; // shorter intervals provide a smoother progress animation
 interface TimerProps extends CircularProgressProps {
@@ -20,6 +21,13 @@ interface TimerProps extends CircularProgressProps {
     tooltipTitle?: TooltipProps['title'];
 }
 
+const styles = {
+    container: { 
+        position: 'relative', 
+        display: 'inline-flex'
+    }
+}
+
 const Timer: React.FC<TimerProps> = ({
     activeTurn,
     children,
@@ -31,6 +39,8 @@ const Timer: React.FC<TimerProps> = ({
     timeRemaining,
     tooltipTitle,
     ...props }) => {
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('md'));
     // Decreases turn time every 100ms, to provide a smooth countdown animation
     React.useEffect(() => {
         const timer = setInterval(() => {
@@ -65,10 +75,10 @@ const Timer: React.FC<TimerProps> = ({
                     )
             }
         >
-            <Box sx={{ position: 'relative', display: 'inline-flex', transform: { xs: 'scale(0.7)', md: 'none' } }}>
+            <Box sx={styles.container}>
                 <CircularProgress
                     variant='determinate'
-                    size={80}
+                    size={isMobile ? 44 : 80}
                     value={(timeRemaining / (maxTime / 100))} // Must be value between 0-100
                     sx={{
                         color: timerColor,


### PR DESCRIPTION
## Change

On mobile last played card is either invisible or super tiny. This PR decreases timer size and paddings to let it grow a little.

## Current behavior

### Mobile - Landscape - last played card smaller than timer

<img width="2532" height="1170" alt="landscape_mobile_bug" src="https://github.com/user-attachments/assets/72074ce7-cbb0-4387-ad99-dabe883e3023" />

### Mobile - Portrait - last played card doesn't show up

<img width="450" alt="portrait_mobile_bug" src="https://github.com/user-attachments/assets/0b0ce271-01ed-46c3-841f-5845fd68a063" />



## Changes 


### Mobile - Landscape
<img width="2532" height="1170" alt="mobile_landscape_fix" src="https://github.com/user-attachments/assets/e6305c78-4aef-41a6-87dc-f83c4d9808f5" />

### Mobile - Portrait
<img width="450" alt="portrait_mobile_fix" src="https://github.com/user-attachments/assets/5754329e-4850-4612-903f-9dc7d5fd76f6" />


### Desktop - No changes

<img width="2062" height="1680" alt="desktop_no_changes" src="https://github.com/user-attachments/assets/33ba615a-a397-4770-b5c7-926f24b91568" />