### PR TITLE
Move game exit action to drawer header

### DIFF
--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -128,7 +128,7 @@ const styles = {
     headerActionsStyle: {
         display: 'flex',
         alignItems: 'center',
-        gap: '0.5rem',
+        gap: '0.35rem',
         ml: 'auto',
     },
     drawerActionButton: {
@@ -161,6 +161,9 @@ const styles = {
             marginLeft: 0,
             marginRight: '6px',
         },
+    },
+    headerCircularButton: {
+        padding: '8px',
     },
     quickUndoButtonEnabled: {
         borderColor: 'rgba(255, 255, 255, 0.12)',
@@ -291,6 +294,7 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
     const {
         gameState,
         gameMessages,
+        sendMessage,
         sendGameMessage,
         sendLobbyMessage,
         isSpectator,
@@ -299,6 +303,7 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
         getOpponent,
         isAnonymousPlayer,
         hasChatDisabled,
+        gameIsEnded,
     } = useGame();
     const { handleTypingStateOnChange, resetTypingState } = useChatTypingState();
     const [chatMessage, setChatMessage] = useState('')
@@ -417,6 +422,9 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
         closeMobileDrawer();
         if (isSpectator){
             router.push('/');
+        } else if (gameIsEnded()) {
+            sendMessage('manualDisconnect');
+            router.push('/');
         } else {
             openPopup('leaveGame', {
                 uuid: `${uuidv4()}`,
@@ -469,15 +477,24 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
     const drawerContent = (
         <>
             <Box sx={styles.headerBoxStyle}>
+                {shouldShowUndo && (<UndoButton disabledOverride={!isUndoEnabled} />)}
                 <Box sx={styles.headerActionsStyle}>
-                    {shouldShowUndo && (<UndoButton disabledOverride={!isUndoEnabled} />)}
+                    <Tooltip title="Leave game">
+                        <IconButton
+                            aria-label="Leave game"
+                            onClick={handleLeaveGameClick}
+                            sx={[styles.drawerActionButton, styles.headerCircularButton]}
+                        >
+                            <LogoutIcon />
+                        </IconButton>
+                    </Tooltip>
                     <IconButton
                         aria-label="game menu"
                         aria-controls={isMenuOpen ? 'chat-drawer-game-menu' : undefined}
                         aria-haspopup="true"
                         aria-expanded={isMenuOpen ? 'true' : undefined}
                         onClick={handleMenuOpen}
-                        sx={styles.drawerActionButton}
+                        sx={[styles.drawerActionButton, styles.headerCircularButton]}
                     >
                         <MoreHorizIcon />
                     </IconButton>
@@ -519,12 +536,6 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
                                 <ListItemText>Concede game</ListItemText>
                             </MenuItem>
                         )}
-                        <MenuItem onClick={handleLeaveGameClick}>
-                            <ListItemIcon sx={styles.menuIcon}>
-                                <LogoutIcon fontSize="small" />
-                            </ListItemIcon>
-                            <ListItemText>Leave game</ListItemText>
-                        </MenuItem>
                     </Menu>
                 </Box>
             </Box>


### PR DESCRIPTION
Moves the Leave Game action from the overflow menu into the drawer header and repositions the Undo button for a clearer layout.

  - Skips confirmation after the game has ended.
  - Preserves the existing spectator exit behavior.

## UI

<img width="442" height="307" alt="Screenshot 2026-08-05 at 1 36 41 PM" src="https://github.com/user-attachments/assets/b2eed78d-9354-4a88-b418-7210a632220b" />

<img width="675" height="313" alt="Screenshot 2026-08-05 at 2 06 10 PM" src="https://github.com/user-attachments/assets/772db8e9-64cc-4d85-ac28-ab50605b13f8" />

<img width="1678" height="925" alt="Screenshot 2026-08-05 at 2 05 30 PM" src="https://github.com/user-attachments/assets/8da49ced-01d7-48f2-9e48-dc43a64b60c6" />

<img width="391" height="846" alt="Screenshot 2026-08-05 at 2 05 53 PM" src="https://github.com/user-attachments/assets/ffcdb6a8-293b-44a1-bd70-9ba45f1e58d5" />
