### PR TITLE
Fix chat drawer menu divider visibility

### DIFF
--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -527,14 +527,16 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
                                 <ListItemText>{isReportingDisabled ? 'Reporting disabled' : 'Report Opponent'}</ListItemText>
                             </MenuItem>
                         )}
-                        <Divider sx={{ borderColor: 'rgba(255, 255, 255, 0.14)' }} />
                         {!isSpectator && (
-                            <MenuItem onClick={handleConcedeClick}>
-                                <ListItemIcon sx={styles.menuIcon}>
-                                    <OutlinedFlagIcon fontSize="small" />
-                                </ListItemIcon>
-                                <ListItemText>Concede game</ListItemText>
-                            </MenuItem>
+                            <>
+                                <Divider sx={{ borderColor: 'rgba(255, 255, 255, 0.14)' }} />
+                                <MenuItem onClick={handleConcedeClick}>
+                                    <ListItemIcon sx={styles.menuIcon}>
+                                        <OutlinedFlagIcon fontSize="small" />
+                                    </ListItemIcon>
+                                    <ListItemText>Concede game</ListItemText>
+                                </MenuItem>
+                            </>
                         )}
                     </Menu>
                 </Box>


### PR DESCRIPTION
# Bug

Menu divider still present when no option is rendered inside (spectator mode).

<img width="275" height="174" alt="Screenshot 2026-08-05 at 8 45 41 PM" src="https://github.com/user-attachments/assets/a6fa0c00-4eea-468e-a3ff-7e783dd6099d" />

