### PR TITLE
If space is not enough, make undo button smaller

### DIFF
--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -48,6 +48,8 @@ const styles = {
             backgroundColor: 'rgba(0, 0, 0, 0.25)',
         },
         '& .MuiDrawer-paper': {
+            containerName: 'chat-drawer',
+            containerType: 'inline-size',
             backgroundColor: { xs: '#000000E6', md: '#000000CC' },
             color: '#fff',
             display: 'flex',
@@ -160,6 +162,16 @@ const styles = {
         '& .MuiButton-startIcon': {
             marginLeft: 0,
             marginRight: '6px',
+        },
+        '@container chat-drawer (max-width: 174.99px)': {
+            padding: '8px',
+            borderRadius: '50%',
+            '& .MuiButton-startIcon': {
+                marginRight: 0,
+            },
+            '& .undo-button-label': {
+                display: 'none',
+            },
         },
     },
     headerCircularButton: {
@@ -279,7 +291,7 @@ const UndoButton = ({ disabledOverride = false }: { disabledOverride?: boolean }
                     startIcon={buttonIcon}
                     sx={[styles.drawerActionButton, styles.undoActionButton, undoButtonStyle]}
                 >
-                    {buttonText}
+                    <span className="undo-button-label">{buttonText}</span>
                 </Button>
             </span>
         </Tooltip>


### PR DESCRIPTION
# Bug 

On small mobile devices/lanscape, quick action buttons don't seem to fit:

<img width="1600" height="738" alt="WhatsApp Image 2026-08-06 at 6 15 36 PM" src="https://github.com/user-attachments/assets/67e38fba-f240-4b30-9d90-1077c72fb9a1" />


# Fix

Use a media query for the container to use a smaller "undo button":

https://github.com/user-attachments/assets/c42ee981-8525-48f8-a5f9-53d4a393b002

