### PR TITLE
If space is not enough, move quick leave button to overflow menu

### DIFF
--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -549,14 +549,12 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
                             <ListItemText>Leave game</ListItemText>
                         </MenuItem>
                         {!isSpectator && (
-
                             <MenuItem onClick={handleConcedeClick}>
                                 <ListItemIcon sx={styles.menuIcon}>
                                     <OutlinedFlagIcon fontSize="small" />
                                 </ListItemIcon>
                                 <ListItemText>Concede game</ListItemText>
                             </MenuItem>
-
                         )}
                     </Menu>
                 </Box>

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -48,6 +48,8 @@ const styles = {
             backgroundColor: 'rgba(0, 0, 0, 0.25)',
         },
         '& .MuiDrawer-paper': {
+            containerName: 'chat-drawer',
+            containerType: 'inline-size',
             backgroundColor: { xs: '#000000E6', md: '#000000CC' },
             color: '#fff',
             display: 'flex',
@@ -160,6 +162,16 @@ const styles = {
         '& .MuiButton-startIcon': {
             marginLeft: 0,
             marginRight: '6px',
+        },
+        '@container chat-drawer (max-width: 174.99px)': {
+            padding: '8px',
+            borderRadius: '50%',
+            '& .MuiButton-startIcon': {
+                marginRight: 0,
+            },
+            '& .undo-button-label': {
+                display: 'none',
+            },
         },
     },
     headerCircularButton: {
@@ -279,7 +291,7 @@ const UndoButton = ({ disabledOverride = false }: { disabledOverride?: boolean }
                     startIcon={buttonIcon}
                     sx={[styles.drawerActionButton, styles.undoActionButton, undoButtonStyle]}
                 >
-                    {buttonText}
+                    <span className="undo-button-label">{buttonText}</span>
                 </Button>
             </span>
         </Tooltip>

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -48,8 +48,6 @@ const styles = {
             backgroundColor: 'rgba(0, 0, 0, 0.25)',
         },
         '& .MuiDrawer-paper': {
-            containerName: 'chat-drawer',
-            containerType: 'inline-size',
             backgroundColor: { xs: '#000000E6', md: '#000000CC' },
             color: '#fff',
             display: 'flex',
@@ -163,19 +161,20 @@ const styles = {
             marginLeft: 0,
             marginRight: '6px',
         },
-        '@container chat-drawer (max-width: 174.99px)': {
-            padding: '8px',
-            borderRadius: '50%',
-            '& .MuiButton-startIcon': {
-                marginRight: 0,
-            },
-            '& .undo-button-label': {
-                display: 'none',
-            },
-        },
     },
     headerCircularButton: {
         padding: '8px',
+    },
+    headerLeaveGameAction: {
+        '@media (orientation: landscape) and (max-width: 875px)': {
+            display: 'none',
+        },
+    },
+    menuLeaveGameAction: {
+        display: 'none',
+        '@media (orientation: landscape) and (max-width: 875px)': {
+            display: 'flex',
+        },
     },
     quickUndoButtonEnabled: {
         borderColor: 'rgba(255, 255, 255, 0.12)',
@@ -291,7 +290,7 @@ const UndoButton = ({ disabledOverride = false }: { disabledOverride?: boolean }
                     startIcon={buttonIcon}
                     sx={[styles.drawerActionButton, styles.undoActionButton, undoButtonStyle]}
                 >
-                    <span className="undo-button-label">{buttonText}</span>
+                    {buttonText}
                 </Button>
             </span>
         </Tooltip>
@@ -495,7 +494,7 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
                         <IconButton
                             aria-label="Leave game"
                             onClick={handleLeaveGameClick}
-                            sx={[styles.drawerActionButton, styles.headerCircularButton]}
+                            sx={[styles.drawerActionButton, styles.headerCircularButton, styles.headerLeaveGameAction]}
                         >
                             <LogoutIcon />
                         </IconButton>
@@ -539,16 +538,22 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
                                 <ListItemText>{isReportingDisabled ? 'Reporting disabled' : 'Report Opponent'}</ListItemText>
                             </MenuItem>
                         )}
+                        <Divider sx={{ borderColor: 'rgba(255, 255, 255, 0.14)' }} />
+                        <MenuItem onClick={handleLeaveGameClick} sx={styles.menuLeaveGameAction}>
+                            <ListItemIcon sx={styles.menuIcon}>
+                                <LogoutIcon fontSize="small" />
+                            </ListItemIcon>
+                            <ListItemText>Leave game</ListItemText>
+                        </MenuItem>
                         {!isSpectator && (
-                            <>
-                                <Divider sx={{ borderColor: 'rgba(255, 255, 255, 0.14)' }} />
-                                <MenuItem onClick={handleConcedeClick}>
-                                    <ListItemIcon sx={styles.menuIcon}>
-                                        <OutlinedFlagIcon fontSize="small" />
-                                    </ListItemIcon>
-                                    <ListItemText>Concede game</ListItemText>
-                                </MenuItem>
-                            </>
+
+                            <MenuItem onClick={handleConcedeClick}>
+                                <ListItemIcon sx={styles.menuIcon}>
+                                    <OutlinedFlagIcon fontSize="small" />
+                                </ListItemIcon>
+                                <ListItemText>Concede game</ListItemText>
+                            </MenuItem>
+
                         )}
                     </Menu>
                 </Box>

--- a/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
+++ b/src/app/_components/Gameboard/_subcomponents/Overlays/ChatDrawer/ChatDrawer.tsx
@@ -301,6 +301,7 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
     const isMobileLandscape = useMediaQuery('(orientation: landscape) and (max-width: 932px)');
+    const isLeaveGameMenuItemVisible = useMediaQuery('(orientation: landscape) and (max-width: 875px)');
     const usesTemporaryDrawer = isMobile && !isMobileLandscape;
     const {
         gameState,
@@ -538,7 +539,9 @@ const ChatDrawer: React.FC<IChatDrawerProps> = ({ sidebarOpen, toggleSidebar, pr
                                 <ListItemText>{isReportingDisabled ? 'Reporting disabled' : 'Report Opponent'}</ListItemText>
                             </MenuItem>
                         )}
-                        <Divider sx={{ borderColor: 'rgba(255, 255, 255, 0.14)' }} />
+                        {(!isSpectator || isLeaveGameMenuItemVisible) && (
+                            <Divider sx={{ borderColor: 'rgba(255, 255, 255, 0.14)' }} />
+                        )}
                         <MenuItem onClick={handleLeaveGameClick} sx={styles.menuLeaveGameAction}>
                             <ListItemIcon sx={styles.menuIcon}>
                                 <LogoutIcon fontSize="small" />


### PR DESCRIPTION
Important: Squash merge please

## Bug

On small mobile devices/lanscape, quick action buttons don't seem to fit:

<img width="1600" height="738" alt="bug" src="https://github.com/user-attachments/assets/17218851-1924-435f-bd7e-89ac7c581920" />



## Change -small mobile landscape only-

<img height="450" alt="localhost_3000_(iPhone SE)" src="https://github.com/user-attachments/assets/e2dd4f2a-5010-442a-8690-f5a276dd98a3" />


## Other resolutions remains same


<img width="450" alt="localhost_3000_(iPhone XR) (1)" src="https://github.com/user-attachments/assets/e3e71735-1985-46a6-8c38-58975edc0057" />
<img height="450" alt="localhost_3000_(iPhone XR)" src="https://github.com/user-attachments/assets/a465f3e7-36d9-4504-a631-426da05b20bf" />
