### PR TITLE
Require a deck selection before enabling Join Queue / Create Game

### DIFF
--- a/src/app/_components/_sharedcomponents/CreateGameForm/CreateGameForm.tsx
+++ b/src/app/_components/_sharedcomponents/CreateGameForm/CreateGameForm.tsx
@@ -124,8 +124,18 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
     const isSavedDeckSelectionLoading = showSavedDecks && !useSwuStatsDecks && (userLoading || isLoadingSavedDecks);
     const isSwuStatsDeckSelectionLoading = showSavedDecks && useSwuStatsDecks && isSwuStatsLinked && isLoadingSwuStatsDecks;
     const isNewDeckInputEmpty = !showSavedDecks && deckLink.trim().length === 0;
-    const isCreateGameDisabled = isSavedDeckSelectionLoading || isSwuStatsDeckSelectionLoading || isNewDeckInputEmpty;
+    const isSwuStatsDeckSource = showSavedDecks && useSwuStatsDecks && isSwuStatsLinked;
+    const hasNoSavedDecksAvailable = showSavedDecks &&
+        (isSwuStatsDeckSource ? swuStatsDecks.length === 0 : savedDecks.length === 0);
+    const isSavedDeckEmpty = showSavedDecks && !favoriteDeck;
+    const isCreateGameDisabled = isSavedDeckSelectionLoading || isSwuStatsDeckSelectionLoading || isNewDeckInputEmpty || isSavedDeckEmpty;
     const showDeckLinkRequiredError = deckLinkTouched && isNewDeckInputEmpty;
+    // The SWU Stats dropdown renders its own empty-state message in the field, so don't duplicate it there.
+    const showSavedDeckHint = isSavedDeckEmpty && !isSavedDeckSelectionLoading &&
+        !isSwuStatsDeckSelectionLoading && !(hasNoSavedDecksAvailable && isSwuStatsDeckSource);
+    const savedDeckHintText = hasNoSavedDecksAvailable
+        ? 'No saved decks found. Use New Deck to add one.'
+        : 'Select a deck to continue.';
 
     useEffect(() => {
         handleJsonDeck(deckLink);
@@ -327,6 +337,10 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
             color: 'var(--initiative-red);',
             mt: '0.5rem'
         },
+        hintMessageStyle: {
+            color: '#aaa',
+            mt: '0.5rem'
+        },
         errorMessageLink:{
             cursor: 'pointer',
             color: 'var(--selection-red);',
@@ -503,7 +517,11 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
                     <>
                         <FormControl fullWidth sx={styles.formControlStyle}>
                             {renderKarabastDecksDropdown()}
-                            
+                            {showSavedDeckHint && (
+                                <Typography variant="body1" sx={styles.hintMessageStyle}>
+                                    {savedDeckHintText}
+                                </Typography>
+                            )}
                             <Box sx={styles.manageDecksContainer}>
                                 <Button
                                     onClick={handleDeckManagement}
@@ -529,7 +547,11 @@ const CreateGameForm: React.FC<ICreateGameFormProps> = ({
                     <>
                         <FormControl fullWidth sx={styles.formControlStyle}>
                             {renderSwuStatsDecksDropdown()}
-                            
+                            {showSavedDeckHint && (
+                                <Typography variant="body1" sx={styles.hintMessageStyle}>
+                                    {savedDeckHintText}
+                                </Typography>
+                            )}
                             <Box sx={styles.manageDecksContainer}>
                                 <Button
                                     href="https://swustats.net"

--- a/src/app/_components/_sharedcomponents/QuickGameForm/QuickGameForm.tsx
+++ b/src/app/_components/_sharedcomponents/QuickGameForm/QuickGameForm.tsx
@@ -120,8 +120,18 @@ const QuickGameForm: React.FC<IQuickGameFormProps> = ({
     const isSavedDeckSelectionLoading = showSavedDecks && !useSwuStatsDecks && (userLoading || isLoadingSavedDecks);
     const isSwuStatsDeckSelectionLoading = showSavedDecks && useSwuStatsDecks && isSwuStatsLinked && isLoadingSwuStatsDecks;
     const isNewDeckInputEmpty = !showSavedDecks && deckLink.trim().length === 0;
-    const isJoinQueueDisabled = queueState || isSavedDeckSelectionLoading || isSwuStatsDeckSelectionLoading || isNewDeckInputEmpty;
+    const isSwuStatsDeckSource = showSavedDecks && useSwuStatsDecks && isSwuStatsLinked;
+    const hasNoSavedDecksAvailable = showSavedDecks &&
+        (isSwuStatsDeckSource ? swuStatsDecks.length === 0 : savedDecks.length === 0);
+    const isSavedDeckEmpty = showSavedDecks && !favoriteDeck;
+    const isJoinQueueDisabled = queueState || isSavedDeckSelectionLoading || isSwuStatsDeckSelectionLoading || isNewDeckInputEmpty || isSavedDeckEmpty;
     const showDeckLinkRequiredError = deckLinkTouched && isNewDeckInputEmpty;
+    // The SWU Stats dropdown renders its own empty-state message in the field, so don't duplicate it there.
+    const showSavedDeckHint = isSavedDeckEmpty && !isSavedDeckSelectionLoading &&
+        !isSwuStatsDeckSelectionLoading && !(hasNoSavedDecksAvailable && isSwuStatsDeckSource);
+    const savedDeckHintText = hasNoSavedDecksAvailable
+        ? 'No saved decks found. Use New Deck to add one.'
+        : 'Select a deck to continue.';
 
     // Timer ref for clearing the inline text after 5s
 
@@ -326,6 +336,10 @@ const QuickGameForm: React.FC<IQuickGameFormProps> = ({
             color: 'var(--initiative-red);',
             mt: '0.5rem'
         },
+        hintMessageStyle: {
+            color: '#aaa',
+            mt: '0.5rem'
+        },
         errorMessageLinkPlain:{
             ml: '2px',
             cursor: 'pointer',
@@ -485,7 +499,11 @@ const QuickGameForm: React.FC<IQuickGameFormProps> = ({
                 {showSavedDecks && !useSwuStatsDecks && (
                     <FormControl fullWidth sx={styles.formControlStyle}>
                         {renderKarabastDecksDropdown()}
-                        
+                        {showSavedDeckHint && (
+                            <Typography variant="body1" sx={styles.hintMessageStyle}>
+                                {savedDeckHintText}
+                            </Typography>
+                        )}
                         <Box sx={styles.manageDecksContainer}>
                             <Button
                                 onClick={handleDeckManagement}
@@ -499,7 +517,11 @@ const QuickGameForm: React.FC<IQuickGameFormProps> = ({
                 {showSavedDecks && useSwuStatsDecks && isSwuStatsLinked && (
                     <FormControl fullWidth sx={styles.formControlStyle}>
                         {renderSwuStatsDecksDropdown()}
-                        
+                        {showSavedDeckHint && (
+                            <Typography variant="body1" sx={styles.hintMessageStyle}>
+                                {savedDeckHintText}
+                            </Typography>
+                        )}
                         <Box sx={styles.manageDecksContainer}>
                             <Button
                                 href="https://swustats.net"


### PR DESCRIPTION
The disabled check on both buttons only covered the New Deck path — it
looked at whether the deck link box was empty. In Saved Deck mode nothing
checked if you'd actually picked a deck, so the button stayed clickable
with an empty dropdown.

Added a check for that in both forms, plus a short line under the dropdown
saying why the button is greyed out. I went with plain grey text instead of
the red error styling, since you haven't really done anything wrong yet.

If you have no saved decks at all, the message points you at New Deck
instead. The dropdown's "No saved decks found" only shows up once you open
it, so with it closed you'd just get a blank field and a dead button with
no explanation.

Tested locally: with decks saved, with none saved, on both tabs, and
confirmed the New Deck path still behaves the same. I couldn't test the SWU
Stats deck source since I don't have an account linked.

Fixes https://github.com/SWU-Karabast/forceteki-client/issues/743