### PR TITLE
Render base upgrades (Fortify)

### DIFF
--- a/src/app/_components/Gameboard/Board/Board.tsx
+++ b/src/app/_components/Gameboard/Board/Board.tsx
@@ -311,6 +311,7 @@ const Board: React.FC<IBoardProps> = ({
                                 cardStyle={LeaderBaseCardStyle.Base}
                                 card={opponentBase}
                                 capturedCards={opponentBase.capturedCards || []}
+                                upgrades={opponentBase.upgrades || []}
                             />
                         </Box>
                     </Box>
@@ -326,6 +327,7 @@ const Board: React.FC<IBoardProps> = ({
                                 cardStyle={LeaderBaseCardStyle.Base}
                                 card={playerBase}
                                 capturedCards={playerBase.capturedCards || []}
+                                upgrades={playerBase.upgrades || []}
                             />
                         </Box>
                         <Box sx={styles.leaderBaseWrapper}>

--- a/src/app/_components/_sharedcomponents/Cards/CardTypes.ts
+++ b/src/app/_components/_sharedcomponents/Cards/CardTypes.ts
@@ -69,6 +69,7 @@ export interface ICardData {
     type: string;
     subcards?: ICardData[];
     capturedCards?: ICardData[];
+    upgrades?: ICardData[];
     aspects?: IAspect[];
     printedType?: string;
     sentinel?: boolean;
@@ -143,6 +144,7 @@ export interface ILeaderBaseCardProps {
     title?: string;
     card: ICardData | null;
     capturedCards?: ICardData[];
+    upgrades?: ICardData[];
     disabled?: boolean;
     cardStyle?: LeaderBaseCardStyle;
     isLeader?: boolean;

--- a/src/app/_components/_sharedcomponents/Cards/LeaderBaseCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/LeaderBaseCard.tsx
@@ -474,7 +474,8 @@ const LeaderBaseCard: React.FC<ILeaderBaseCardProps> = ({
             position: 'relative',
             mb: isConnectedPlayer ? '-4%' : '0px',
             mt: isConnectedPlayer ? '0px' : '-4%',
-            zIndex: 1
+            // sits above the adjacent upgrade strip so the "Captured" divider stays fully legible
+            zIndex: 2
         }}>
             {!isConnectedPlayer && (
                 <Typography sx={styles.capturedCardsDivider}>
@@ -529,11 +530,6 @@ const LeaderBaseCard: React.FC<ILeaderBaseCardProps> = ({
             mt: isConnectedPlayer ? '0px' : '-4%',
             zIndex: 1
         }}>
-            {!isConnectedPlayer && (
-                <Typography sx={styles.capturedCardsDivider}>
-                    Upgrades
-                </Typography>
-            )}
             {upgrades.map((upgrade: ICardData) => (
                 <Box
                     key={`base-upgrade-${upgrade.uuid}`}
@@ -564,11 +560,6 @@ const LeaderBaseCard: React.FC<ILeaderBaseCardProps> = ({
                     </Typography>
                 </Box>
             ))}
-            {isConnectedPlayer && (
-                <Typography sx={styles.capturedCardsDivider}>
-                    Upgrades
-                </Typography>
-            )}
         </Box>
     )
 

--- a/src/app/_components/_sharedcomponents/Cards/LeaderBaseCard.tsx
+++ b/src/app/_components/_sharedcomponents/Cards/LeaderBaseCard.tsx
@@ -20,6 +20,7 @@ const LeaderBaseCard: React.FC<ILeaderBaseCardProps> = ({
     title,
     cardStyle = LeaderBaseCardStyle.Plain,
     capturedCards = [],
+    upgrades = [],
     disabled = false,
     isLeader = false,
 }) => {
@@ -518,9 +519,63 @@ const LeaderBaseCard: React.FC<ILeaderBaseCardProps> = ({
         </Box>
     )
 
+    // Base upgrades (via the Fortify keyword) render as aspect-colored strips tucked against the base,
+    // mirroring the captured-cards decoration above.
+    const upgradesDecoration = (
+        <Box sx={{
+            width: '100%',
+            position: 'relative',
+            mb: isConnectedPlayer ? '-4%' : '0px',
+            mt: isConnectedPlayer ? '0px' : '-4%',
+            zIndex: 1
+        }}>
+            {!isConnectedPlayer && (
+                <Typography sx={styles.capturedCardsDivider}>
+                    Upgrades
+                </Typography>
+            )}
+            {upgrades.map((upgrade: ICardData) => (
+                <Box
+                    key={`base-upgrade-${upgrade.uuid}`}
+                    sx={{
+                        ...styles.capturedCardIcon,
+                        cursor: upgrade.selectable ? 'pointer' : 'default',
+                    }}
+                    onClick={() => subcardClick(upgrade)}
+                    onMouseEnter={handlePreviewOpen}
+                    onMouseLeave={handlePreviewClose}
+                    {...longPressHandlers}
+                    data-card-url={s3CardImageURL({ ...upgrade, setId: upgrade.setId }, locale)}
+                    data-card-type={upgrade.printedType}
+                    data-card-id={upgrade.setId ? upgrade.setId.set + '_' + upgrade.setId.number : upgrade.id}
+                >
+                    {/* Background image element positioned behind text */}
+                    <Box
+                        sx={{
+                            ...styles.capturedCardBackground,
+                            backgroundImage: `url(${capturedCardBackground(upgrade)})`,
+                            border: upgrade.selectable ? `1.5px solid ${getBorderColor({ card: upgrade, player: connectedPlayer })}` : 'none',
+                        }}
+                    />
+                    <Typography sx={{
+                        ...styles.capturedCardName
+                    }}>
+                        {upgrade.name}
+                    </Typography>
+                </Box>
+            ))}
+            {isConnectedPlayer && (
+                <Typography sx={styles.capturedCardsDivider}>
+                    Upgrades
+                </Typography>
+            )}
+        </Box>
+    )
+
     return (
         <Box sx={{ width: '100%' }}>
             {capturedCards.length > 0 && isConnectedPlayer && capturedCardsDecoration}
+            {upgrades.length > 0 && isConnectedPlayer && upgradesDecoration}
             <Box
                 sx={isDeployed ? styles.deployedPlaceholder : [styles.card, highlightSx]}
                 onClick={handleClick}
@@ -629,6 +684,7 @@ const LeaderBaseCard: React.FC<ILeaderBaseCardProps> = ({
                     </>
                 )}
             </Box>
+            {upgrades.length > 0 && !isConnectedPlayer && upgradesDecoration}
             {capturedCards.length > 0 && !isConnectedPlayer && capturedCardsDecoration}
         </Box>
     );


### PR DESCRIPTION
⚠️ Engine PR: SWU-Karabast/forceteki#2657

Renders upgrades attached to a base, for the new **Fortify** base-upgrade mechanic.

- `ICardData` / `ILeaderBaseCardProps` gain `upgrades`; the engine now nests base-upgrade summaries on the base state (self-contained on the `base` object, so no new card pile).
- `Board.tsx` passes each base's `upgrades`; `LeaderBaseCard` renders them, reusing the captured-unit strip styling (no "Upgrades" divider, matching how units display).