### PR TITLE
Add HMW to PREVIEW_SETS

### DIFF
--- a/images-scripts/process_cards.py
+++ b/images-scripts/process_cards.py
@@ -158,7 +158,7 @@ PER_SET_LANDSCAPE_DOUBLE_LEADERS: dict[str, set[int]] = {
 # via S3 CopyObject (no body re-upload, no data-transfer cost).
 CACHE_CONTROL_DEFAULT = "public, max-age=31536000, immutable"
 CACHE_CONTROL_PREVIEW = "public, max-age=604800, immutable"
-PREVIEW_SETS: set[str] = {"IC27"}
+PREVIEW_SETS: set[str] = {"IC27", "HMW"}
 
 
 def cache_control_for(set_code: str) -> str:


### PR DESCRIPTION
Adds HMW (Homeworlds) to `PREVIEW_SETS` so its preview card images upload with the 1-week cache header while art is still churning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)