### PR TITLE
Replace alert() calls with an in-app error screen

### DIFF
--- a/src/app/DeckPage/page.tsx
+++ b/src/app/DeckPage/page.tsx
@@ -23,6 +23,7 @@ import {
     updateDeckFavoriteInLocalStorage,
 } from '@/app/_utils/ServerAndLocalStorageUtils';
 import { useUser } from '@/app/_contexts/User.context';
+import { useErrorScreen } from '@/app/_contexts/ErrorScreen.context';
 import { useSession } from 'next-auth/react';
 
 interface IDeckSummaryCardTileProps {
@@ -69,6 +70,7 @@ const DeckPage: React.FC = () => {
     const router = useRouter();
     const { data: session } = useSession(); // Get session from next-auth
     const { user } = useUser();
+    const { showErrorScreen } = useErrorScreen();
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
     // Load decks from localStorage on component mount
@@ -82,7 +84,17 @@ const DeckPage: React.FC = () => {
             // Call the loadDecks function and await the result
             await retrieveDecksForUser(session?.user, user,{ format:'display', setDecks: setDecks });
         } catch (error) {
-            alert('Server error when fetching decks');
+            showErrorScreen({
+                title: 'Couldn\'t load your decks',
+                message: 'The server didn\'t respond when we asked for your saved decks.',
+                actions: (dismiss) => [
+                    { label: 'Try again', variant: 'concede', onClick: () => {
+                        dismiss();
+                        fetchDecks();
+                    } },
+                    { label: 'Dismiss', onClick: dismiss },
+                ],
+            });
             console.error('Error fetching decks:', error);
         }
     };
@@ -219,7 +231,10 @@ const DeckPage: React.FC = () => {
 
             setDecks(sortedDecks);
         }catch(error){
-            alert('There was an error when toggling favorite.');
+            showErrorScreen({
+                title: 'Couldn\'t update favorite',
+                message: 'We couldn\'t change the favorite status of that deck. Your decks are unchanged.',
+            });
             console.log(error)
         }
     };

--- a/src/app/_components/ClientProviders/ClientProviders.tsx
+++ b/src/app/_components/ClientProviders/ClientProviders.tsx
@@ -6,6 +6,7 @@ import { PopupProvider } from '@/app/_contexts/Popup.context';
 import { ThemeContextProvider } from '@/app/_contexts/Theme.context';
 import { TimerVisibilityProvider } from '@/app/_contexts/TimerVisibility.context';
 import { UserProvider } from '@/app/_contexts/User.context';
+import { ErrorScreenProvider } from '@/app/_contexts/ErrorScreen.context';
 import { SessionProvider } from 'next-auth/react';
 import { OngoingEffectHighlightProvider } from '@/app/_contexts/OngoingEffectHighlight.context';
 
@@ -22,7 +23,9 @@ const ClientProviders: React.FC<IClientProvidersProps> = ({ children }) => {
                         <PopupProvider>
                             <OngoingEffectHighlightProvider>
                                 <CosmeticsProvider>
-                                    <ThemeContextProvider>{children}</ThemeContextProvider>
+                                    <ThemeContextProvider>
+                                        <ErrorScreenProvider>{children}</ErrorScreenProvider>
+                                    </ThemeContextProvider>
                                 </CosmeticsProvider>
                             </OngoingEffectHighlightProvider>
                         </PopupProvider>

--- a/src/app/_components/HomePage/_subcomponents/JoinableGame/JoinableGame.tsx
+++ b/src/app/_components/HomePage/_subcomponents/JoinableGame/JoinableGame.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box, Button, Typography } from '@mui/material';
 import { useRouter } from 'next/navigation';
 import { useUser } from '@/app/_contexts/User.context';
+import { useErrorScreen } from '@/app/_contexts/ErrorScreen.context';
 import { IJoinableGameProps } from '../../HomePageTypes';
 import { ISetCode } from '@/app/_components/_sharedcomponents/Cards/CardTypes';
 import OverlappingCards from '../OverlappingCards/OverlappingCards';
@@ -18,6 +19,7 @@ import Bo3Icon from '/public/bo3.svg';
 const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
     const router = useRouter();
     const { user } = useUser();
+    const { showErrorScreen } = useErrorScreen();
 
     const joinLobby = async (lobbyId: string) => {
         try {
@@ -37,7 +39,11 @@ const JoinableGame: React.FC<IJoinableGameProps> = ({ lobby }) => {
             if (!response.ok) {
                 const errorData = await response.json();
                 console.error('Error joining lobby:', errorData.message);
-                alert(errorData.message);
+                showErrorScreen({
+                    title: 'Couldn\'t join that game',
+                    message: 'You weren\'t able to join this lobby. It may have filled up or been closed.',
+                    detail: errorData.message,
+                });
                 return;
             }
             router.push('/lobby');

--- a/src/app/_components/QuickGame/SearchingForGame/SearchingForGame.tsx
+++ b/src/app/_components/QuickGame/SearchingForGame/SearchingForGame.tsx
@@ -3,6 +3,7 @@ import { Box, Card, Typography } from '@mui/material';
 import { useGame } from '@/app/_contexts/Game.context';
 import { useRouter } from 'next/navigation';
 import { useUser } from '@/app/_contexts/User.context';
+import { useErrorScreen } from '@/app/_contexts/ErrorScreen.context';
 import MatchLoader from './MatchLoader';
 const styles = {
     searchBox: {
@@ -40,14 +41,31 @@ const SearchingForGame: React.FC = () => {
     const router = useRouter();
     const lastQueueHeartbeatState = useRef<number>(0);
     const { user, anonymousUserId } = useUser();
+    const { showErrorScreen } = useErrorScreen();
 
     useEffect(() => {
         timerRef.current = setInterval(() => {
             const secondsSinceLastHeartbeat = Math.floor((Date.now() - lastQueueHeartbeatState.current) / 1000);
 
             if (secondsSinceLastHeartbeat > 15) {
-                alert(`Connection lost. Please try again.\nUser ID: ${user?.id || anonymousUserId}`);
-                router.push('/');
+                // The user now leaves via the error screen rather than being redirected
+                // immediately, so stop polling or this would fire every second.
+                if (timerRef.current) {
+                    clearInterval(timerRef.current);
+                }
+                showErrorScreen({
+                    title: 'Connection lost',
+                    message: 'We lost contact with the matchmaking queue, so you\'ve been taken out of it. Try joining again.',
+                    detail: `User ID: ${user?.id || anonymousUserId}`,
+                    actions: (dismiss) => [{
+                        label: 'Return to main menu',
+                        variant: 'concede',
+                        onClick: () => {
+                            dismiss();
+                            router.push('/');
+                        },
+                    }],
+                });
                 return;
             }
 

--- a/src/app/_components/_sharedcomponents/Error/ErrorCardOverlay.tsx
+++ b/src/app/_components/_sharedcomponents/Error/ErrorCardOverlay.tsx
@@ -1,0 +1,186 @@
+'use client';
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, Typography } from '@mui/material';
+import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
+
+export interface IErrorScreenAction {
+    label: string;
+    onClick: () => void;
+
+    /** 'concede' renders the red treatment, 'standard' the neutral one. Defaults to standard. */
+    variant?: 'concede' | 'standard';
+}
+
+interface IErrorCardOverlayProps {
+    open: boolean;
+    title: string;
+    message: string;
+
+    /** Extra technical detail (raw server text). Shown smaller, under the message. */
+    detail?: string;
+    actions: IErrorScreenAction[];
+}
+
+const FLIP_DELAY_MS = 450;
+const FLIP_DURATION_MS = 900;
+
+/**
+ * Full-screen error display styled as a Star Wars Unlimited card that flips over to
+ * reveal the error. Sits on the site background so it reads as part of Karabast rather
+ * than a browser dialog.
+ */
+export const ErrorCardOverlay: React.FC<IErrorCardOverlayProps> = ({
+    open,
+    title,
+    message,
+    detail,
+    actions,
+}) => {
+    const [flipped, setFlipped] = useState(false);
+    const actionsRef = useRef<HTMLDivElement | null>(null);
+
+    // Respect reduced-motion: show the error face immediately instead of animating.
+    const prefersReducedMotion = typeof window !== 'undefined' &&
+        window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+
+    useEffect(() => {
+        if (!open) {
+            setFlipped(false);
+            return;
+        }
+
+        if (prefersReducedMotion) {
+            setFlipped(true);
+            return;
+        }
+
+        const timer = setTimeout(() => setFlipped(true), FLIP_DELAY_MS);
+        return () => clearTimeout(timer);
+    }, [open, prefersReducedMotion]);
+
+    // Move focus to the first action once the error face is actually readable.
+    useEffect(() => {
+        if (!flipped) {
+            return;
+        }
+
+        const delay = prefersReducedMotion ? 0 : FLIP_DURATION_MS;
+        const timer = setTimeout(() => {
+            actionsRef.current?.querySelector('button')?.focus();
+        }, delay);
+        return () => clearTimeout(timer);
+    }, [flipped, prefersReducedMotion]);
+
+    if (!open) {
+        return null;
+    }
+
+    const styles = {
+        overlay: {
+            position: 'fixed',
+            inset: 0,
+            zIndex: 1400,
+            backgroundImage: 'url(/default-background.webp)',
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '1.5rem',
+        },
+        scene: {
+            perspective: '1400px',
+            width: 'min(24rem, 88vw)',
+        },
+        card: {
+            position: 'relative',
+            width: '100%',
+            aspectRatio: '1 / 1.4',
+            transformStyle: 'preserve-3d',
+            transition: prefersReducedMotion ? 'none' : `transform ${FLIP_DURATION_MS}ms cubic-bezier(.4,.15,.2,1)`,
+            transform: flipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
+        },
+        face: {
+            position: 'absolute',
+            inset: 0,
+            backfaceVisibility: 'hidden',
+            borderRadius: '5px',
+        },
+        // Matches the deck pile's card back treatment so it reads as the same object.
+        cardBack: {
+            backgroundColor: 'black',
+            backgroundImage: 'url(/card-back.png)',
+            backgroundSize: '100%',
+            backgroundPosition: 'center',
+            backgroundRepeat: 'no-repeat',
+            border: '1px solid #2A2F36',
+        },
+        cardFront: {
+            transform: 'rotateY(180deg)',
+            backgroundColor: 'rgba(0, 0, 0, 0.88)',
+            border: '2px solid var(--initiative-red)',
+            padding: '1.5rem',
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+        },
+        title: {
+            color: 'var(--initiative-red)',
+            fontSize: '1.3rem',
+            fontWeight: 600,
+            mb: '0.75rem',
+        },
+        body: {
+            flexGrow: 1,
+            overflowY: 'auto',
+            mb: '1rem',
+        },
+        message: {
+            color: '#CFD6DF',
+            fontSize: '1rem',
+            lineHeight: 1.6,
+        },
+        detail: {
+            color: '#8A94A2',
+            fontSize: '0.8rem',
+            lineHeight: 1.5,
+            mt: '0.75rem',
+            wordBreak: 'break-word',
+        },
+        actions: {
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '0.5rem',
+        },
+    };
+
+    return (
+        <Box sx={styles.overlay} role="alertdialog" aria-modal="true" aria-label={title}>
+            <Box sx={styles.scene}>
+                <Box sx={styles.card}>
+                    <Box sx={{ ...styles.face, ...styles.cardBack }} aria-hidden="true" />
+                    <Box sx={{ ...styles.face, ...styles.cardFront }}>
+                        <Typography sx={styles.title}>{title}</Typography>
+                        <Box sx={styles.body}>
+                            <Typography sx={styles.message}>{message}</Typography>
+                            {detail && <Typography sx={styles.detail}>{detail}</Typography>}
+                        </Box>
+                        <Box sx={styles.actions} ref={actionsRef}>
+                            {actions.map((action) => (
+                                <PreferenceButton
+                                    key={action.label}
+                                    variant={action.variant ?? 'standard'}
+                                    text={action.label}
+                                    buttonFnc={action.onClick}
+                                    sx={{ width: '100%' }}
+                                />
+                            ))}
+                        </Box>
+                    </Box>
+                </Box>
+            </Box>
+        </Box>
+    );
+};
+
+export default ErrorCardOverlay;

--- a/src/app/_components/_sharedcomponents/LinkService/LinkServiceButton.tsx
+++ b/src/app/_components/_sharedcomponents/LinkService/LinkServiceButton.tsx
@@ -9,6 +9,7 @@ import {
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { useUser } from '@/app/_contexts/User.context';
+import { useErrorScreen } from '@/app/_contexts/ErrorScreen.context';
 import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_subComponents/PreferenceButton';
 import { IUser } from '@/app/_contexts/UserTypes';
 
@@ -29,6 +30,7 @@ function LinkServiceButton({
 }: Props) {
     const theme = useTheme();
     const { user } = useUser();
+    const { showErrorScreen } = useErrorScreen();
     const [showConfirmDialog, setShowConfirmDialog] = useState(false);
 
     const handleClick = async () => {
@@ -45,7 +47,11 @@ function LinkServiceButton({
             onLinkChange(false);
         } catch (error) {
             if (error instanceof Error) {
-                alert(error.message);
+                showErrorScreen({
+                    title: `Couldn't unlink ${serviceName}`,
+                    message: `We couldn't unlink your ${serviceName} account. Your account is unchanged - try again in a moment.`,
+                    detail: error.message,
+                });
             }
             console.error(`Failed to unlink ${serviceName}:`, error);
         } finally {

--- a/src/app/_contexts/ErrorScreen.context.tsx
+++ b/src/app/_contexts/ErrorScreen.context.tsx
@@ -1,0 +1,73 @@
+'use client';
+import React, { createContext, useCallback, useContext, useMemo, useState, ReactNode } from 'react';
+import ErrorCardOverlay, { IErrorScreenAction } from '@/app/_components/_sharedcomponents/Error/ErrorCardOverlay';
+
+export interface IErrorScreenRequest {
+    title: string;
+    message: string;
+
+    /** Raw technical detail (e.g. a server message) shown under the main copy. */
+    detail?: string;
+
+    /**
+     * Recovery options offered to the user. Each receives a `dismiss` callback so an
+     * action can close the screen as well as do its own work. Defaults to a single
+     * "Dismiss" button when omitted.
+     */
+    actions?: (dismiss: () => void) => IErrorScreenAction[];
+}
+
+interface IErrorScreenContext {
+    showErrorScreen: (request: IErrorScreenRequest) => void;
+    hideErrorScreen: () => void;
+}
+
+const ErrorScreenContext = createContext<IErrorScreenContext | undefined>(undefined);
+
+/**
+ * Provides the full-screen error card used in place of browser `alert()` dialogs.
+ * Lives above both the game board and the standalone pages so any of them can raise
+ * an error without knowing where it will be drawn.
+ */
+export const ErrorScreenProvider = ({ children }: { children: ReactNode }) => {
+    const [request, setRequest] = useState<IErrorScreenRequest | null>(null);
+
+    const hideErrorScreen = useCallback(() => setRequest(null), []);
+    const showErrorScreen = useCallback((next: IErrorScreenRequest) => setRequest(next), []);
+
+    const actions = useMemo(() => {
+        if (!request) {
+            return [];
+        }
+
+        return request.actions
+            ? request.actions(hideErrorScreen)
+            : [{ label: 'Dismiss', onClick: hideErrorScreen }];
+    }, [request, hideErrorScreen]);
+
+    const value = useMemo(
+        () => ({ showErrorScreen, hideErrorScreen }),
+        [showErrorScreen, hideErrorScreen]
+    );
+
+    return (
+        <ErrorScreenContext.Provider value={value}>
+            {children}
+            <ErrorCardOverlay
+                open={request !== null}
+                title={request?.title ?? ''}
+                message={request?.message ?? ''}
+                detail={request?.detail}
+                actions={actions}
+            />
+        </ErrorScreenContext.Provider>
+    );
+};
+
+export const useErrorScreen = () => {
+    const context = useContext(ErrorScreenContext);
+    if (!context) {
+        throw new Error('useErrorScreen must be used within an ErrorScreenProvider');
+    }
+    return context;
+};

--- a/src/app/_contexts/Game.context.tsx
+++ b/src/app/_contexts/Game.context.tsx
@@ -23,6 +23,7 @@ import { IStatsNotification } from '@/app/_components/_sharedcomponents/Preferen
 import { hasSelectedCards } from '../_utils/gameStateHelpers';
 import { useGameMessages, IMessageDelta, IMessageRetransmit } from '@/app/_hooks/useGameMessages';
 import { IChatEntry } from '@/app/_components/_sharedcomponents/Chat/ChatTypes';
+import { useErrorScreen } from '@/app/_contexts/ErrorScreen.context';
 import { IOngoingEffectSummary } from '@/app/_components/_sharedcomponents/Cards/CardTypes';
 
 interface IGameContextType {
@@ -68,6 +69,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     const [lastQueueHeartbeat, setLastQueueHeartbeat] = useState(Date.now());
     const [connectedPlayer, setConnectedPlayer] = useState<string>('');
     const [hoveredChatCardId, setHoveredCardId] = useState<string | null>(null);
+    const { showErrorScreen } = useErrorScreen();
     const { openPopup, clearPopups, prunePromptStatePopups } = usePopup();
     const { user, anonymousUserId } = useUser();
     const [isSpectator, setIsSpectator] = useState<boolean>(false);
@@ -294,8 +296,19 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
 
         newSocket.on('connection_error', (error: any) => {
             console.error('Error joining lobby:', error);
-            alert(error);
-            router.push('/');
+            showErrorScreen({
+                title: 'Couldn\'t join the game',
+                message: 'We couldn\'t connect you to this game. It may have already ended or no longer exists.',
+                detail: typeof error === 'string' ? error : error?.message,
+                actions: (dismiss) => [{
+                    label: 'Return to main menu',
+                    variant: 'concede',
+                    onClick: () => {
+                        dismiss();
+                        router.push('/');
+                    },
+                }],
+            });
         });
 
         newSocket.on('matchmakingFailed', (error: any) => {
@@ -303,8 +316,22 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
             resetStates();
         });
 
-        newSocket.on('inactiveDisconnect', () => {            
-            alert('You have been disconnected due to inactivity');
+        newSocket.on('inactiveDisconnect', () => {
+            // The server removes the user from the lobby on an inactivity disconnect,
+            // so there is nothing to rejoin - returning home is the only way forward.
+            showErrorScreen({
+                title: 'Disconnected due to inactivity',
+                message: 'You were removed from the game because there was no activity for a while. The game has gone on without you.',
+                actions: (dismiss) => [{
+                    label: 'Return to main menu',
+                    variant: 'concede',
+                    onClick: () => {
+                        dismiss();
+                        resetStates();
+                        router.push('/');
+                    },
+                }],
+            });
             newSocket.disconnect();
         });
 

--- a/src/app/_hooks/useDeckManagement.ts
+++ b/src/app/_hooks/useDeckManagement.ts
@@ -8,6 +8,7 @@ import {
     ISwuStatsDeckItem 
 } from '@/app/_utils/ServerAndLocalStorageUtils';
 import { useUser } from '@/app/_contexts/User.context';
+import { useErrorScreen } from '@/app/_contexts/ErrorScreen.context';
 import { useSession } from 'next-auth/react';
 
 export interface IDeckPreferences {
@@ -48,6 +49,7 @@ export interface IDeckManagementState {
 export const useDeckManagement = (): IDeckManagementState => {
     const { user } = useUser();
     const { data: session } = useSession();
+    const { showErrorScreen } = useErrorScreen();
     
     // Deck Preferences State
     const [showSavedDecks, setShowSavedDecks] = useState<boolean>(() => {
@@ -292,11 +294,22 @@ export const useDeckManagement = (): IDeckManagementState => {
             });
         } catch (error) {
             console.error('Error fetching decks:', error);
-            alert('Server error when fetching decks');
+            showErrorScreen({
+                title: 'Couldn\'t load your decks',
+                message: 'The server didn\'t respond when we asked for your saved decks.',
+                actions: (dismiss) => [
+                    { label: 'Try again', variant: 'concede', onClick: () => {
+                        dismiss();
+                        fetchDecks();
+                    } },
+                    { label: 'Dismiss', onClick: dismiss },
+                ],
+            });
         } finally {
             setIsLoadingSavedDecks(false);
         }
-    }, [session?.user, user, handleInitializeDeckSelection]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [session?.user, user, handleInitializeDeckSelection, showErrorScreen]);
 
     const handleShowSavedDecksChange = useCallback((value: boolean) => {
         setShowSavedDecks(value);

--- a/src/app/mod/subpages/CosmeticsManagerTab.tsx
+++ b/src/app/mod/subpages/CosmeticsManagerTab.tsx
@@ -23,6 +23,7 @@ import PreferenceButton from '@/app/_components/_sharedcomponents/Preferences/_s
 import { ICosmeticEntity, RegisteredCosmeticType } from '@/app/_components/_sharedcomponents/Preferences/Preferences.types';
 import { v4 as uuidv4 } from 'uuid';
 import { useCosmetics } from '@/app/_contexts/CosmeticsContext';
+import { useErrorScreen } from '@/app/_contexts/ErrorScreen.context';
 import { ServerApiService } from '@/app/_services/ServerApiService';
 
 interface ImageDimensions {
@@ -40,6 +41,7 @@ const isDev = process.env.NODE_ENV === 'development';
 
 const CosmeticsManagerTab: React.FC = () => {
     const { cosmetics, setCosmetics, fetchCosmetics } = useCosmetics();
+    const { showErrorScreen } = useErrorScreen();
     const [filteredCosmetics, setFilteredCosmetics] = useState<ICosmeticEntity[]>([]);
     const [availableTypes, setAvailableTypes] = useState<string[]>([]);
     const [loading, setLoading] = useState(true);
@@ -365,7 +367,11 @@ const CosmeticsManagerTab: React.FC = () => {
         }
         const response = await ServerApiService.deleteCosmeticAsync(cosmeticId);
         if (!response.success) {
-            alert('Failed to delete cosmetic');
+            showErrorScreen({
+                title: 'Couldn\'t delete cosmetic',
+                message: `The cosmetic "${cosmeticId}" was not deleted.`,
+                detail: response.message,
+            });
             console.error('Delete error:', response.message);
         }
 


### PR DESCRIPTION

<img width="720" height="475" alt="image-1786915036938" src="https://github.com/user-attachments/assets/b423bc85-e9ef-460f-b7c4-a0d810736f03" />

Browser alert() dialogs were used for every error the client surfaced. They sit outside the app, can't be styled, and offer no way to recover beyond an OK button - alert(error) in the socket handler even dumped a raw error object at the user.

Add an ErrorScreenProvider that renders errors as a Star Wars Unlimited card on the site background, which flips over to reveal what went wrong. The card back reuses /card-back.png with the same treatment as the deck pile, so it reads as part of the game rather than a browser dialog.

Callers use showErrorScreen({ title, message, detail, actions }). Actions receive a dismiss callback, so each error can offer whatever recovery makes sense - returning to the main menu for fatal connection errors, retrying for failed fetches, dismissing for everything else. Raw server text goes in the detail field, under a readable sentence, instead of being the whole message.

The provider lives in ClientProviders so it wraps both the game board and the standalone pages. Game.context now uses it rather than holding its own error state.

Also clears the heartbeat interval in SearchingForGame before showing the error. The user now leaves via the error screen instead of being redirected immediately, so without this it would fire every second.

The card honours prefers-reduced-motion by skipping the flip, and moves focus to the first recovery action once the error is readable.

Fixes #756